### PR TITLE
feat: Add CSS themes with light/dark mode support

### DIFF
--- a/SwiftMarkdown.xcodeproj/project.pbxproj
+++ b/SwiftMarkdown.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		00293CBBC4C6FE8A96200412 /* TreeSitterSwift in Frameworks */ = {isa = PBXBuildFile; productRef = AEE67E32DEF8BDAD82D22C87 /* TreeSitterSwift */; };
+		0E5BC65A4C34D2C20A13C184 /* SyntaxTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D864EB38F9DA2270E06F31 /* SyntaxTheme.swift */; };
 		1046C44370268572EE44F2BA /* PreviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F1EBA2B5AC2DA7FBD61F12 /* PreviewViewController.swift */; };
 		1ADF709C413D3EF737BD00D6 /* SwiftMarkdownCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 327502C2C9568E4497D68E2D /* SwiftMarkdownCore.swift */; };
 		497FDC1338C5EF65407603A9 /* PlainTextRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6EA9AC7D0321DC237CAA56 /* PlainTextRendererTests.swift */; };
@@ -15,6 +16,7 @@
 		4B765172AAD959C57FFDCB93 /* ImageValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60124B861E67B3E2919B216 /* ImageValidatorTests.swift */; };
 		54F77ED86A73956332B1BD16 /* ImageValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E01F16278E86C893DE1324F /* ImageValidator.swift */; };
 		5DEBE8F448112FD03EE248BD /* TreeSitterHighlighter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0CDD889C6D996E0721E08B1 /* TreeSitterHighlighter.swift */; };
+		6369C1964EA36F2BFAD11691 /* highlight.css in Resources */ = {isa = PBXBuildFile; fileRef = 42761C721193A258C1ABC5E4 /* highlight.css */; };
 		670291E5C7A987E8FBECBC5B /* SwiftTreeSitter in Frameworks */ = {isa = PBXBuildFile; productRef = 49FDA8082BBBFFD3378F9F36 /* SwiftTreeSitter */; };
 		6F1693EF64350907439D32E1 /* MarkdownRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC3C7E294336DAA8FA4C403E /* MarkdownRenderer.swift */; };
 		7E4E0ADB9F632919888A92E7 /* SwiftMarkdownCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 95F447A42C55828BB50C30B5 /* SwiftMarkdownCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -23,6 +25,7 @@
 		9BC7D5E80962F3FB38E4A7FB /* MarkdownParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = DACBD54BE4C8A5E5D4E205F0 /* MarkdownParser.swift */; };
 		9C2B9CA834D9FBFA2B467B8C /* SyntaxHighlighterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5D9247F726F851B63E511B7 /* SyntaxHighlighterTests.swift */; };
 		A02C25D7D5EB7A7FA04FA3A2 /* SwiftMarkdownCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 95F447A42C55828BB50C30B5 /* SwiftMarkdownCore.framework */; };
+		B6BAEE9D266B0B4E25F36503 /* SyntaxThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A5BCE3B3DF1F9E273618397 /* SyntaxThemeTests.swift */; };
 		BA7F9CF67F2CA0DD3BF41A89 /* SwiftMarkdownApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC245DFE823E1914F1368A1C /* SwiftMarkdownApp.swift */; };
 		BB50D8E05328216766C5515F /* SwiftMarkdownCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 95F447A42C55828BB50C30B5 /* SwiftMarkdownCore.framework */; };
 		C3B167FD38C733B112E277FF /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BB6B52D45ED0A11407D90A /* ContentView.swift */; };
@@ -86,6 +89,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		01D864EB38F9DA2270E06F31 /* SyntaxTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyntaxTheme.swift; sourceTree = "<group>"; };
 		0870ADD570D5EF2C00DA1C40 /* SyntaxHighlighter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyntaxHighlighter.swift; sourceTree = "<group>"; };
 		09AA4F3A79326A0FCC93CA54 /* PlainTextRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlainTextRenderer.swift; sourceTree = "<group>"; };
 		1D5E5838A8AEC4E0FDC523A2 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -94,7 +98,9 @@
 		3780132CA9FEA0CDFEEA695B /* SwiftMarkdown.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftMarkdown.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		3BC2CEE945099FDCED3EEFCD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		3E01F16278E86C893DE1324F /* ImageValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageValidator.swift; sourceTree = "<group>"; };
+		42761C721193A258C1ABC5E4 /* highlight.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = highlight.css; sourceTree = "<group>"; };
 		586261D1054B4DCE992C88D3 /* SwiftMarkdownTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftMarkdownTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		5A5BCE3B3DF1F9E273618397 /* SyntaxThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyntaxThemeTests.swift; sourceTree = "<group>"; };
 		6567C09B42A4181208919050 /* SwiftMarkdownQuickLook.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = SwiftMarkdownQuickLook.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		7849291C823F0BF4608BF436 /* SwiftMarkdown.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SwiftMarkdown.entitlements; sourceTree = "<group>"; };
 		7896D51841ECD93C0A8119A0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -184,6 +190,14 @@
 			path = Rendering;
 			sourceTree = "<group>";
 		};
+		7EC75CB94AF4E588B3655B20 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				42761C721193A258C1ABC5E4 /* highlight.css */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
 		9AA6EB949A275C4B3F588ECD /* SwiftMarkdown */ = {
 			isa = PBXGroup;
 			children = (
@@ -213,9 +227,19 @@
 				327502C2C9568E4497D68E2D /* SwiftMarkdownCore.swift */,
 				EC8D33E3CF310183FC6EBC29 /* ImageValidation */,
 				6CF0A81CBFB87846AF2CCB79 /* Rendering */,
+				7EC75CB94AF4E588B3655B20 /* Resources */,
 				AF34805A2D1689DE9AEA6290 /* SyntaxHighlighting */,
+				CAEF476CC89E8866F9857693 /* Themes */,
 			);
 			path = SwiftMarkdownCore;
+			sourceTree = "<group>";
+		};
+		CAEF476CC89E8866F9857693 /* Themes */ = {
+			isa = PBXGroup;
+			children = (
+				01D864EB38F9DA2270E06F31 /* SyntaxTheme.swift */,
+			);
+			path = Themes;
 			sourceTree = "<group>";
 		};
 		D5DEA205A88634C80F940D38 /* Products */ = {
@@ -247,6 +271,7 @@
 				AE6EA9AC7D0321DC237CAA56 /* PlainTextRendererTests.swift */,
 				D59B743B5EFB7435B9954AAA /* SwiftMarkdownCoreTests.swift */,
 				C5D9247F726F851B63E511B7 /* SyntaxHighlighterTests.swift */,
+				5A5BCE3B3DF1F9E273618397 /* SyntaxThemeTests.swift */,
 			);
 			path = SwiftMarkdownTests;
 			sourceTree = "<group>";
@@ -279,6 +304,7 @@
 			buildConfigurationList = 92B1E38E48D7406D45C89E1F /* Build configuration list for PBXNativeTarget "SwiftMarkdownCore" */;
 			buildPhases = (
 				A6B532E7CCE286A4EAFCFCC9 /* Sources */,
+				EEB9343DBE02440F75190D6A /* Resources */,
 				DDA593888ADCD89036A7A925 /* Frameworks */,
 			);
 			buildRules = (
@@ -382,6 +408,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		EEB9343DBE02440F75190D6A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6369C1964EA36F2BFAD11691 /* highlight.css in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -404,6 +438,7 @@
 				497FDC1338C5EF65407603A9 /* PlainTextRendererTests.swift in Sources */,
 				8664876EDFD44FCB3F6F20AF /* SwiftMarkdownCoreTests.swift in Sources */,
 				9C2B9CA834D9FBFA2B467B8C /* SyntaxHighlighterTests.swift in Sources */,
+				B6BAEE9D266B0B4E25F36503 /* SyntaxThemeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -418,6 +453,7 @@
 				F6E7533793D2B14E0BD4DF7F /* PlainTextRenderer.swift in Sources */,
 				1ADF709C413D3EF737BD00D6 /* SwiftMarkdownCore.swift in Sources */,
 				F3C0DBD72E43F100AE91CECE /* SyntaxHighlighter.swift in Sources */,
+				0E5BC65A4C34D2C20A13C184 /* SyntaxTheme.swift in Sources */,
 				5DEBE8F448112FD03EE248BD /* TreeSitterHighlighter.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SwiftMarkdownCore/Rendering/HTMLRenderer.swift
+++ b/SwiftMarkdownCore/Rendering/HTMLRenderer.swift
@@ -15,9 +15,15 @@ import Markdown
 /// ```
 public final class HTMLRenderer: HTMLMarkdownRenderer {
     /// CSS styles to include with rendered HTML.
-    /// Currently returns empty string; will be populated when themes are added.
+    /// Returns the bundled highlight.css, or falls back to generated CSS if unavailable.
     public var cssStyles: String {
-        return ""
+        // Try to load bundled CSS from framework resources
+        if let url = Bundle(for: HTMLRenderer.self).url(forResource: "highlight", withExtension: "css"),
+           let css = try? String(contentsOf: url) {
+            return css
+        }
+        // Fallback to generated CSS from default theme
+        return SyntaxTheme.default.generateCSS()
     }
 
     /// Whether to wrap output in a complete HTML document.

--- a/SwiftMarkdownCore/Resources/highlight.css
+++ b/SwiftMarkdownCore/Resources/highlight.css
@@ -1,0 +1,67 @@
+/* SwiftMarkdown Syntax Highlighting Styles */
+
+/* Code block styling */
+pre {
+    background-color: #f5f5f5;
+    border-radius: 6px;
+    padding: 16px;
+    overflow-x: auto;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 14px;
+    line-height: 1.5;
+}
+
+@media (prefers-color-scheme: dark) {
+    pre {
+        background-color: #1e1e1e;
+    }
+}
+
+code {
+    font-family: inherit;
+}
+
+/* Syntax token colors - light theme (default) */
+:root {
+    --syntax-keyword: #af00db;
+    --syntax-string: #a31515;
+    --syntax-comment: #008000;
+    --syntax-number: #098658;
+    --syntax-function: #795e26;
+    --syntax-type: #267f99;
+    --syntax-variable: #001080;
+    --syntax-operator: #000000;
+    --syntax-punctuation: #000000;
+    --syntax-property: #001080;
+    --syntax-attribute: #795e26;
+}
+
+/* Dark theme */
+@media (prefers-color-scheme: dark) {
+    :root {
+        --syntax-keyword: #c586c0;
+        --syntax-string: #ce9178;
+        --syntax-comment: #6a9955;
+        --syntax-number: #b5cea8;
+        --syntax-function: #dcdcaa;
+        --syntax-type: #4ec9b0;
+        --syntax-variable: #9cdcfe;
+        --syntax-operator: #d4d4d4;
+        --syntax-punctuation: #d4d4d4;
+        --syntax-property: #9cdcfe;
+        --syntax-attribute: #dcdcaa;
+    }
+}
+
+/* Token classes */
+.token-keyword { color: var(--syntax-keyword); }
+.token-string { color: var(--syntax-string); }
+.token-comment { color: var(--syntax-comment); font-style: italic; }
+.token-number { color: var(--syntax-number); }
+.token-function { color: var(--syntax-function); }
+.token-type { color: var(--syntax-type); }
+.token-variable { color: var(--syntax-variable); }
+.token-operator { color: var(--syntax-operator); }
+.token-punctuation { color: var(--syntax-punctuation); }
+.token-property { color: var(--syntax-property); }
+.token-attribute { color: var(--syntax-attribute); }

--- a/SwiftMarkdownCore/Themes/SyntaxTheme.swift
+++ b/SwiftMarkdownCore/Themes/SyntaxTheme.swift
@@ -1,0 +1,156 @@
+import Foundation
+
+/// Defines colors for syntax highlighting tokens.
+///
+/// Use the static `.light` and `.dark` presets for standard themes,
+/// or create custom themes with your own colors.
+public struct SyntaxColors: Equatable, Sendable {
+    public var keyword: String
+    public var string: String
+    public var comment: String
+    public var number: String
+    public var function: String
+    public var type: String
+    public var variable: String
+    public var `operator`: String
+    public var punctuation: String
+    public var property: String
+    public var attribute: String
+
+    public init(
+        keyword: String,
+        string: String,
+        comment: String,
+        number: String,
+        function: String,
+        type: String,
+        variable: String,
+        operator: String,
+        punctuation: String,
+        property: String,
+        attribute: String
+    ) {
+        self.keyword = keyword
+        self.string = string
+        self.comment = comment
+        self.number = number
+        self.function = function
+        self.type = type
+        self.variable = variable
+        self.operator = `operator`
+        self.punctuation = punctuation
+        self.property = property
+        self.attribute = attribute
+    }
+
+    /// Light theme colors inspired by VS Code Light+.
+    public static let light = SyntaxColors(
+        keyword: "#af00db",
+        string: "#a31515",
+        comment: "#008000",
+        number: "#098658",
+        function: "#795e26",
+        type: "#267f99",
+        variable: "#001080",
+        operator: "#000000",
+        punctuation: "#000000",
+        property: "#001080",
+        attribute: "#795e26"
+    )
+
+    /// Dark theme colors inspired by VS Code Dark+.
+    public static let dark = SyntaxColors(
+        keyword: "#c586c0",
+        string: "#ce9178",
+        comment: "#6a9955",
+        number: "#b5cea8",
+        function: "#dcdcaa",
+        type: "#4ec9b0",
+        variable: "#9cdcfe",
+        operator: "#d4d4d4",
+        punctuation: "#d4d4d4",
+        property: "#9cdcfe",
+        attribute: "#dcdcaa"
+    )
+}
+
+/// A theme for syntax highlighting with light and dark mode support.
+///
+/// Themes are defined using CSS custom properties (variables) which enables
+/// automatic light/dark mode switching via `prefers-color-scheme` media query.
+///
+/// ## Example
+/// ```swift
+/// let theme = SyntaxTheme.default
+/// let css = theme.generateCSS()
+/// // Use css in your HTML document
+/// ```
+public struct SyntaxTheme: Equatable, Sendable {
+    /// Colors for light mode.
+    public var light: SyntaxColors
+
+    /// Colors for dark mode.
+    public var dark: SyntaxColors
+
+    public init(light: SyntaxColors, dark: SyntaxColors) {
+        self.light = light
+        self.dark = dark
+    }
+
+    /// The default theme with VS Code-inspired light and dark colors.
+    public static let `default` = SyntaxTheme(light: .light, dark: .dark)
+
+    /// Generates CSS with custom properties for both light and dark modes.
+    ///
+    /// The generated CSS includes:
+    /// - CSS variables in `:root` for light mode (default)
+    /// - CSS variables in `@media (prefers-color-scheme: dark)` for dark mode
+    /// - Token classes that reference the CSS variables
+    ///
+    /// - Returns: A CSS string ready to be embedded in an HTML document.
+    public func generateCSS() -> String {
+        """
+        :root {
+            --syntax-keyword: \(light.keyword);
+            --syntax-string: \(light.string);
+            --syntax-comment: \(light.comment);
+            --syntax-number: \(light.number);
+            --syntax-function: \(light.function);
+            --syntax-type: \(light.type);
+            --syntax-variable: \(light.variable);
+            --syntax-operator: \(light.operator);
+            --syntax-punctuation: \(light.punctuation);
+            --syntax-property: \(light.property);
+            --syntax-attribute: \(light.attribute);
+        }
+
+        @media (prefers-color-scheme: dark) {
+            :root {
+                --syntax-keyword: \(dark.keyword);
+                --syntax-string: \(dark.string);
+                --syntax-comment: \(dark.comment);
+                --syntax-number: \(dark.number);
+                --syntax-function: \(dark.function);
+                --syntax-type: \(dark.type);
+                --syntax-variable: \(dark.variable);
+                --syntax-operator: \(dark.operator);
+                --syntax-punctuation: \(dark.punctuation);
+                --syntax-property: \(dark.property);
+                --syntax-attribute: \(dark.attribute);
+            }
+        }
+
+        .token-keyword { color: var(--syntax-keyword); }
+        .token-string { color: var(--syntax-string); }
+        .token-comment { color: var(--syntax-comment); font-style: italic; }
+        .token-number { color: var(--syntax-number); }
+        .token-function { color: var(--syntax-function); }
+        .token-type { color: var(--syntax-type); }
+        .token-variable { color: var(--syntax-variable); }
+        .token-operator { color: var(--syntax-operator); }
+        .token-punctuation { color: var(--syntax-punctuation); }
+        .token-property { color: var(--syntax-property); }
+        .token-attribute { color: var(--syntax-attribute); }
+        """
+    }
+}

--- a/SwiftMarkdownTests/SyntaxThemeTests.swift
+++ b/SwiftMarkdownTests/SyntaxThemeTests.swift
@@ -1,0 +1,184 @@
+import XCTest
+@testable import SwiftMarkdownCore
+
+final class SyntaxThemeTests: XCTestCase {
+    // MARK: - CSS Variable Tests
+
+    func testCSSContainsVariables() {
+        let css = SyntaxTheme.default.generateCSS()
+
+        XCTAssertTrue(css.contains("--syntax-keyword"))
+        XCTAssertTrue(css.contains("--syntax-string"))
+        XCTAssertTrue(css.contains("--syntax-comment"))
+        XCTAssertTrue(css.contains("--syntax-number"))
+        XCTAssertTrue(css.contains("--syntax-function"))
+        XCTAssertTrue(css.contains("--syntax-type"))
+        XCTAssertTrue(css.contains("--syntax-variable"))
+        XCTAssertTrue(css.contains("--syntax-operator"))
+        XCTAssertTrue(css.contains("--syntax-punctuation"))
+        XCTAssertTrue(css.contains("--syntax-property"))
+        XCTAssertTrue(css.contains("--syntax-attribute"))
+    }
+
+    func testCSSContainsDarkModeMediaQuery() {
+        let css = SyntaxTheme.default.generateCSS()
+
+        XCTAssertTrue(css.contains("prefers-color-scheme: dark"))
+    }
+
+    func testCSSContainsTokenClasses() {
+        let css = SyntaxTheme.default.generateCSS()
+
+        XCTAssertTrue(css.contains(".token-keyword"))
+        XCTAssertTrue(css.contains(".token-string"))
+        XCTAssertTrue(css.contains(".token-comment"))
+        XCTAssertTrue(css.contains(".token-number"))
+        XCTAssertTrue(css.contains(".token-function"))
+        XCTAssertTrue(css.contains(".token-type"))
+        XCTAssertTrue(css.contains(".token-variable"))
+        XCTAssertTrue(css.contains(".token-operator"))
+        XCTAssertTrue(css.contains(".token-punctuation"))
+        XCTAssertTrue(css.contains(".token-property"))
+        XCTAssertTrue(css.contains(".token-attribute"))
+    }
+
+    func testCSSTokenClassesUseVariables() {
+        let css = SyntaxTheme.default.generateCSS()
+
+        XCTAssertTrue(css.contains(".token-keyword { color: var(--syntax-keyword)"))
+        XCTAssertTrue(css.contains(".token-string { color: var(--syntax-string)"))
+    }
+
+    func testCommentHasItalicStyle() {
+        let css = SyntaxTheme.default.generateCSS()
+
+        XCTAssertTrue(css.contains(".token-comment { color: var(--syntax-comment); font-style: italic; }"))
+    }
+
+    // MARK: - Color Preset Tests
+
+    func testLightColorsPreset() {
+        let colors = SyntaxColors.light
+
+        XCTAssertEqual(colors.keyword, "#af00db")
+        XCTAssertEqual(colors.string, "#a31515")
+        XCTAssertEqual(colors.comment, "#008000")
+        XCTAssertEqual(colors.number, "#098658")
+        XCTAssertEqual(colors.function, "#795e26")
+        XCTAssertEqual(colors.type, "#267f99")
+        XCTAssertEqual(colors.variable, "#001080")
+    }
+
+    func testDarkColorsPreset() {
+        let colors = SyntaxColors.dark
+
+        XCTAssertEqual(colors.keyword, "#c586c0")
+        XCTAssertEqual(colors.string, "#ce9178")
+        XCTAssertEqual(colors.comment, "#6a9955")
+        XCTAssertEqual(colors.number, "#b5cea8")
+        XCTAssertEqual(colors.function, "#dcdcaa")
+        XCTAssertEqual(colors.type, "#4ec9b0")
+        XCTAssertEqual(colors.variable, "#9cdcfe")
+    }
+
+    // MARK: - Custom Theme Tests
+
+    func testCustomThemeGeneratesValidCSS() {
+        var theme = SyntaxTheme.default
+        theme.light.keyword = "#ff0000"
+        theme.dark.keyword = "#00ff00"
+
+        let css = theme.generateCSS()
+
+        XCTAssertTrue(css.contains("#ff0000"))
+        XCTAssertTrue(css.contains("#00ff00"))
+    }
+
+    func testCustomColorsAreUsed() {
+        let customLight = SyntaxColors(
+            keyword: "#111111",
+            string: "#222222",
+            comment: "#333333",
+            number: "#444444",
+            function: "#555555",
+            type: "#666666",
+            variable: "#777777",
+            operator: "#888888",
+            punctuation: "#999999",
+            property: "#aaaaaa",
+            attribute: "#bbbbbb"
+        )
+
+        let theme = SyntaxTheme(light: customLight, dark: .dark)
+        let css = theme.generateCSS()
+
+        XCTAssertTrue(css.contains("--syntax-keyword: #111111"))
+        XCTAssertTrue(css.contains("--syntax-string: #222222"))
+        XCTAssertTrue(css.contains("--syntax-comment: #333333"))
+    }
+
+    // MARK: - HTMLRenderer CSS Tests
+
+    func testHTMLRendererReturnsCSS() {
+        let renderer = HTMLRenderer()
+
+        XCTAssertFalse(renderer.cssStyles.isEmpty)
+    }
+
+    func testHTMLRendererCSSContainsTokenClasses() {
+        let renderer = HTMLRenderer()
+        let css = renderer.cssStyles
+
+        XCTAssertTrue(css.contains(".token-keyword"))
+        XCTAssertTrue(css.contains(".token-string"))
+    }
+
+    func testHTMLRendererCSSContainsDarkMode() {
+        let renderer = HTMLRenderer()
+        let css = renderer.cssStyles
+
+        XCTAssertTrue(css.contains("prefers-color-scheme: dark"))
+    }
+
+    func testHTMLRendererWrapInDocumentIncludesCSS() {
+        let renderer = HTMLRenderer(wrapInDocument: true)
+        let document = MarkdownParser.parseDocument("# Hello")
+        let html = renderer.render(document)
+
+        XCTAssertTrue(html.contains("<style>"))
+        XCTAssertTrue(html.contains("</style>"))
+        XCTAssertTrue(html.contains(".token-keyword"))
+    }
+
+    // MARK: - Equality Tests
+
+    func testSyntaxColorsEquality() {
+        let colors1 = SyntaxColors.light
+        let colors2 = SyntaxColors.light
+
+        XCTAssertEqual(colors1, colors2)
+    }
+
+    func testSyntaxColorsInequality() {
+        var colors1 = SyntaxColors.light
+        var colors2 = SyntaxColors.light
+        colors2.keyword = "#ffffff"
+
+        XCTAssertNotEqual(colors1, colors2)
+    }
+
+    func testSyntaxThemeEquality() {
+        let theme1 = SyntaxTheme.default
+        let theme2 = SyntaxTheme.default
+
+        XCTAssertEqual(theme1, theme2)
+    }
+
+    func testSyntaxThemeInequality() {
+        var theme1 = SyntaxTheme.default
+        var theme2 = SyntaxTheme.default
+        theme2.light.keyword = "#ffffff"
+
+        XCTAssertNotEqual(theme1, theme2)
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -65,6 +65,9 @@ targets:
     platform: macOS
     sources:
       - SwiftMarkdownCore
+    resources:
+      - path: SwiftMarkdownCore/Resources
+        buildPhase: resources
     dependencies:
       - package: swift-markdown
         product: Markdown


### PR DESCRIPTION
## Summary

Add CSS-based theme system for syntax highlighting with automatic light/dark mode switching.

- Add `SyntaxTheme` and `SyntaxColors` types with VS Code-inspired color presets
- Add `highlight.css` bundled resource with token classes and code block styling
- Update `HTMLRenderer.cssStyles` to load bundled CSS (fallback to generated)
- CSS variables in `:root` with `@media (prefers-color-scheme: dark)` for auto-switching
- 17 new unit tests for theme system

## Test plan

- [x] Build succeeds
- [x] All 112 tests pass (17 new)
- [x] swiftlint passes
- [ ] Manual: Render HTML with `wrapInDocument: true`, toggle system appearance

Closes #8