### PR TITLE
feat: Add GrammarManager for lazy-loading tree-sitter grammars

### DIFF
--- a/SwiftMarkdown.xcodeproj/project.pbxproj
+++ b/SwiftMarkdown.xcodeproj/project.pbxproj
@@ -11,23 +11,30 @@
 		0E5BC65A4C34D2C20A13C184 /* SyntaxTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D864EB38F9DA2270E06F31 /* SyntaxTheme.swift */; };
 		1046C44370268572EE44F2BA /* PreviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F1EBA2B5AC2DA7FBD61F12 /* PreviewViewController.swift */; };
 		1ADF709C413D3EF737BD00D6 /* SwiftMarkdownCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 327502C2C9568E4497D68E2D /* SwiftMarkdownCore.swift */; };
+		1D4D4F6C986946DEFDBEE790 /* GrammarManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B063556DF68B1428DE338C6 /* GrammarManagerTests.swift */; };
 		497FDC1338C5EF65407603A9 /* PlainTextRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6EA9AC7D0321DC237CAA56 /* PlainTextRendererTests.swift */; };
 		4AD0857EDCD7170E75955150 /* HTMLRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C92EEC01DFECF39F9FD67D25 /* HTMLRenderer.swift */; };
 		4B765172AAD959C57FFDCB93 /* ImageValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60124B861E67B3E2919B216 /* ImageValidatorTests.swift */; };
 		54F77ED86A73956332B1BD16 /* ImageValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E01F16278E86C893DE1324F /* ImageValidator.swift */; };
+		5A3162197FD39082852C1554 /* GrammarManifestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8241641705639E7415FA4283 /* GrammarManifestTests.swift */; };
 		5DEBE8F448112FD03EE248BD /* TreeSitterHighlighter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0CDD889C6D996E0721E08B1 /* TreeSitterHighlighter.swift */; };
 		6369C1964EA36F2BFAD11691 /* highlight.css in Resources */ = {isa = PBXBuildFile; fileRef = 42761C721193A258C1ABC5E4 /* highlight.css */; };
+		64165C72A942F3412114805D /* LazyTreeSitterHighlighter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8CB32C563CC962698340BF8 /* LazyTreeSitterHighlighter.swift */; };
 		670291E5C7A987E8FBECBC5B /* SwiftTreeSitter in Frameworks */ = {isa = PBXBuildFile; productRef = 49FDA8082BBBFFD3378F9F36 /* SwiftTreeSitter */; };
 		6F1693EF64350907439D32E1 /* MarkdownRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC3C7E294336DAA8FA4C403E /* MarkdownRenderer.swift */; };
 		7E4E0ADB9F632919888A92E7 /* SwiftMarkdownCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 95F447A42C55828BB50C30B5 /* SwiftMarkdownCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		8664876EDFD44FCB3F6F20AF /* SwiftMarkdownCoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D59B743B5EFB7435B9954AAA /* SwiftMarkdownCoreTests.swift */; };
 		89FEE35070D2A1C17AB6421A /* Markdown in Frameworks */ = {isa = PBXBuildFile; productRef = F10350C361C31733946A2AFA /* Markdown */; };
+		8EC47975A4146FA9820BE9C6 /* GrammarManifest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCAAFBA7E1B67A000AC2B618 /* GrammarManifest.swift */; };
+		91AE9B4B84FEDF679211AC2C /* GrammarManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD3CDE3FFECEED6781027B84 /* GrammarManager.swift */; };
 		9BC7D5E80962F3FB38E4A7FB /* MarkdownParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = DACBD54BE4C8A5E5D4E205F0 /* MarkdownParser.swift */; };
 		9C2B9CA834D9FBFA2B467B8C /* SyntaxHighlighterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5D9247F726F851B63E511B7 /* SyntaxHighlighterTests.swift */; };
 		A02C25D7D5EB7A7FA04FA3A2 /* SwiftMarkdownCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 95F447A42C55828BB50C30B5 /* SwiftMarkdownCore.framework */; };
 		B6BAEE9D266B0B4E25F36503 /* SyntaxThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A5BCE3B3DF1F9E273618397 /* SyntaxThemeTests.swift */; };
 		BA7F9CF67F2CA0DD3BF41A89 /* SwiftMarkdownApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC245DFE823E1914F1368A1C /* SwiftMarkdownApp.swift */; };
 		BB50D8E05328216766C5515F /* SwiftMarkdownCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 95F447A42C55828BB50C30B5 /* SwiftMarkdownCore.framework */; };
+		BD9282D7285DD285D40B7411 /* GrammarError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5441AA30AEECE5EDC9A59126 /* GrammarError.swift */; };
+		BFA78EFE0811FC9BB1CCA532 /* AsyncHTMLWalker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60DAB9333ACF98FC398657DF /* AsyncHTMLWalker.swift */; };
 		C3B167FD38C733B112E277FF /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BB6B52D45ED0A11407D90A /* ContentView.swift */; };
 		C4F792554A8EB669109AD412 /* MarkdownParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89DC4E84AA6CB7A55815B7F /* MarkdownParserTests.swift */; };
 		CB7A8B8305D1E434288A6297 /* FileType in Frameworks */ = {isa = PBXBuildFile; productRef = 7410C581B06A6A5F9663B4CC /* FileType */; };
@@ -99,25 +106,32 @@
 		3BC2CEE945099FDCED3EEFCD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		3E01F16278E86C893DE1324F /* ImageValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageValidator.swift; sourceTree = "<group>"; };
 		42761C721193A258C1ABC5E4 /* highlight.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = highlight.css; sourceTree = "<group>"; };
+		5441AA30AEECE5EDC9A59126 /* GrammarError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrammarError.swift; sourceTree = "<group>"; };
 		586261D1054B4DCE992C88D3 /* SwiftMarkdownTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftMarkdownTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		5A5BCE3B3DF1F9E273618397 /* SyntaxThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyntaxThemeTests.swift; sourceTree = "<group>"; };
+		60DAB9333ACF98FC398657DF /* AsyncHTMLWalker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncHTMLWalker.swift; sourceTree = "<group>"; };
 		6567C09B42A4181208919050 /* SwiftMarkdownQuickLook.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = SwiftMarkdownQuickLook.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		7849291C823F0BF4608BF436 /* SwiftMarkdown.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SwiftMarkdown.entitlements; sourceTree = "<group>"; };
 		7896D51841ECD93C0A8119A0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		7B063556DF68B1428DE338C6 /* GrammarManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrammarManagerTests.swift; sourceTree = "<group>"; };
+		8241641705639E7415FA4283 /* GrammarManifestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrammarManifestTests.swift; sourceTree = "<group>"; };
 		83CD477C1EE8C81739449627 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		95F447A42C55828BB50C30B5 /* SwiftMarkdownCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftMarkdownCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9B786F7F67635FFA4DB2D52B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		AE6EA9AC7D0321DC237CAA56 /* PlainTextRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlainTextRendererTests.swift; sourceTree = "<group>"; };
 		B5BB6B52D45ED0A11407D90A /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		BCAAFBA7E1B67A000AC2B618 /* GrammarManifest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrammarManifest.swift; sourceTree = "<group>"; };
 		C5D9247F726F851B63E511B7 /* SyntaxHighlighterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyntaxHighlighterTests.swift; sourceTree = "<group>"; };
 		C92EEC01DFECF39F9FD67D25 /* HTMLRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTMLRenderer.swift; sourceTree = "<group>"; };
 		CC0732F7FFFF2CB2CA3AAF34 /* HTMLRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTMLRendererTests.swift; sourceTree = "<group>"; };
 		CC3C7E294336DAA8FA4C403E /* MarkdownRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownRenderer.swift; sourceTree = "<group>"; };
+		CD3CDE3FFECEED6781027B84 /* GrammarManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrammarManager.swift; sourceTree = "<group>"; };
 		D59B743B5EFB7435B9954AAA /* SwiftMarkdownCoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftMarkdownCoreTests.swift; sourceTree = "<group>"; };
 		D89DC4E84AA6CB7A55815B7F /* MarkdownParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownParserTests.swift; sourceTree = "<group>"; };
 		DACBD54BE4C8A5E5D4E205F0 /* MarkdownParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownParser.swift; sourceTree = "<group>"; };
 		DC245DFE823E1914F1368A1C /* SwiftMarkdownApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftMarkdownApp.swift; sourceTree = "<group>"; };
 		E0CDD889C6D996E0721E08B1 /* TreeSitterHighlighter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreeSitterHighlighter.swift; sourceTree = "<group>"; };
+		E8CB32C563CC962698340BF8 /* LazyTreeSitterHighlighter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyTreeSitterHighlighter.swift; sourceTree = "<group>"; };
 		F60124B861E67B3E2919B216 /* ImageValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageValidatorTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -183,6 +197,7 @@
 		6CF0A81CBFB87846AF2CCB79 /* Rendering */ = {
 			isa = PBXGroup;
 			children = (
+				60DAB9333ACF98FC398657DF /* AsyncHTMLWalker.swift */,
 				C92EEC01DFECF39F9FD67D25 /* HTMLRenderer.swift */,
 				CC3C7E294336DAA8FA4C403E /* MarkdownRenderer.swift */,
 				09AA4F3A79326A0FCC93CA54 /* PlainTextRenderer.swift */,
@@ -213,6 +228,10 @@
 		AF34805A2D1689DE9AEA6290 /* SyntaxHighlighting */ = {
 			isa = PBXGroup;
 			children = (
+				5441AA30AEECE5EDC9A59126 /* GrammarError.swift */,
+				CD3CDE3FFECEED6781027B84 /* GrammarManager.swift */,
+				BCAAFBA7E1B67A000AC2B618 /* GrammarManifest.swift */,
+				E8CB32C563CC962698340BF8 /* LazyTreeSitterHighlighter.swift */,
 				0870ADD570D5EF2C00DA1C40 /* SyntaxHighlighter.swift */,
 				E0CDD889C6D996E0721E08B1 /* TreeSitterHighlighter.swift */,
 			);
@@ -264,6 +283,8 @@
 		EE46B3B0894560244A3035ED /* SwiftMarkdownTests */ = {
 			isa = PBXGroup;
 			children = (
+				7B063556DF68B1428DE338C6 /* GrammarManagerTests.swift */,
+				8241641705639E7415FA4283 /* GrammarManifestTests.swift */,
 				CC0732F7FFFF2CB2CA3AAF34 /* HTMLRendererTests.swift */,
 				F60124B861E67B3E2919B216 /* ImageValidatorTests.swift */,
 				9B786F7F67635FFA4DB2D52B /* Info.plist */,
@@ -432,6 +453,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1D4D4F6C986946DEFDBEE790 /* GrammarManagerTests.swift in Sources */,
+				5A3162197FD39082852C1554 /* GrammarManifestTests.swift in Sources */,
 				EDB84B1B268301165FBDCB45 /* HTMLRendererTests.swift in Sources */,
 				4B765172AAD959C57FFDCB93 /* ImageValidatorTests.swift in Sources */,
 				C4F792554A8EB669109AD412 /* MarkdownParserTests.swift in Sources */,
@@ -446,8 +469,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BFA78EFE0811FC9BB1CCA532 /* AsyncHTMLWalker.swift in Sources */,
+				BD9282D7285DD285D40B7411 /* GrammarError.swift in Sources */,
+				91AE9B4B84FEDF679211AC2C /* GrammarManager.swift in Sources */,
+				8EC47975A4146FA9820BE9C6 /* GrammarManifest.swift in Sources */,
 				4AD0857EDCD7170E75955150 /* HTMLRenderer.swift in Sources */,
 				54F77ED86A73956332B1BD16 /* ImageValidator.swift in Sources */,
+				64165C72A942F3412114805D /* LazyTreeSitterHighlighter.swift in Sources */,
 				9BC7D5E80962F3FB38E4A7FB /* MarkdownParser.swift in Sources */,
 				6F1693EF64350907439D32E1 /* MarkdownRenderer.swift in Sources */,
 				F6E7533793D2B14E0BD4DF7F /* PlainTextRenderer.swift in Sources */,

--- a/SwiftMarkdownCore/MarkdownParser.swift
+++ b/SwiftMarkdownCore/MarkdownParser.swift
@@ -69,6 +69,22 @@ public struct MarkdownParser {
         return parse(markdown, renderer: renderer, options: options)
     }
 
+    /// Parse markdown to HTML with lazy-loaded syntax highlighting.
+    ///
+    /// This async method supports highlighting for 35+ languages by downloading
+    /// grammars on first use. Swift highlighting is always available immediately.
+    ///
+    /// - Parameters:
+    ///   - markdown: The markdown string to parse.
+    ///   - options: Parsing options (default: .default).
+    /// - Returns: HTML string with syntax-highlighted code blocks.
+    public static func parseWithHighlightingAsync(_ markdown: String, options: Options = .default) async -> String {
+        let document = parseDocument(markdown, options: options)
+        let highlighter = LazyTreeSitterHighlighter()
+        let renderer = HTMLRenderer()
+        return await renderer.renderAsync(document, highlighter: highlighter)
+    }
+
     /// Parse markdown and return the document AST for inspection.
     /// - Parameters:
     ///   - markdown: The markdown string to parse.

--- a/SwiftMarkdownCore/Rendering/AsyncHTMLWalker.swift
+++ b/SwiftMarkdownCore/Rendering/AsyncHTMLWalker.swift
@@ -1,0 +1,294 @@
+import Foundation
+import Markdown
+
+/// An async walker that supports lazy-loaded syntax highlighting.
+struct AsyncHTMLWalker {
+    var result = ""
+    let highlighter: LazyTreeSitterHighlighter
+    let validateImages: Bool
+
+    init(highlighter: LazyTreeSitterHighlighter, validateImages: Bool = false) {
+        self.highlighter = highlighter
+        self.validateImages = validateImages
+    }
+
+    mutating func visit(_ document: Document) async {
+        for child in document.children {
+            await visitMarkup(child)
+        }
+    }
+
+    // swiftlint:disable cyclomatic_complexity
+    private mutating func visitMarkup(_ markup: Markup) async {
+        switch markup {
+        case let heading as Heading:
+            await visitHeading(heading)
+        case let paragraph as Paragraph:
+            visitParagraph(paragraph)
+        case let codeBlock as CodeBlock:
+            await visitCodeBlock(codeBlock)
+        case let unorderedList as UnorderedList:
+            await visitUnorderedList(unorderedList)
+        case let orderedList as OrderedList:
+            await visitOrderedList(orderedList)
+        case let listItem as ListItem:
+            visitListItem(listItem)
+        case let blockQuote as BlockQuote:
+            await visitBlockQuote(blockQuote)
+        case let table as Table:
+            visitTable(table)
+        case let thematicBreak as ThematicBreak:
+            visitThematicBreak(thematicBreak)
+        case let htmlBlock as HTMLBlock:
+            visitHTMLBlock(htmlBlock)
+        case let text as Text:
+            visitText(text)
+        case let emphasis as Emphasis:
+            visitEmphasis(emphasis)
+        case let strong as Strong:
+            visitStrong(strong)
+        case let strikethrough as Strikethrough:
+            visitStrikethrough(strikethrough)
+        case let inlineCode as InlineCode:
+            visitInlineCode(inlineCode)
+        case let link as Link:
+            visitLink(link)
+        case let image as Image:
+            visitImage(image)
+        case let lineBreak as LineBreak:
+            visitLineBreak(lineBreak)
+        case let softBreak as SoftBreak:
+            visitSoftBreak(softBreak)
+        case let inlineHTML as InlineHTML:
+            visitInlineHTML(inlineHTML)
+        default:
+            break
+        }
+    }
+
+    private mutating func visitInlineMarkup(_ markup: Markup) {
+        switch markup {
+        case let text as Text:
+            visitText(text)
+        case let emphasis as Emphasis:
+            visitEmphasis(emphasis)
+        case let strong as Strong:
+            visitStrong(strong)
+        case let strikethrough as Strikethrough:
+            visitStrikethrough(strikethrough)
+        case let inlineCode as InlineCode:
+            visitInlineCode(inlineCode)
+        case let link as Link:
+            visitLink(link)
+        case let image as Image:
+            visitImage(image)
+        case let lineBreak as LineBreak:
+            visitLineBreak(lineBreak)
+        case let softBreak as SoftBreak:
+            visitSoftBreak(softBreak)
+        case let inlineHTML as InlineHTML:
+            visitInlineHTML(inlineHTML)
+        default:
+            break
+        }
+    }
+    // swiftlint:enable cyclomatic_complexity
+
+    private mutating func visitHeading(_ heading: Heading) async {
+        let level = heading.level
+        result += "<h\(level)>"
+        for child in heading.children {
+            await visitMarkup(child)
+        }
+        result += "</h\(level)>\n"
+    }
+
+    private mutating func visitParagraph(_ paragraph: Paragraph) {
+        result += "<p>"
+        for child in paragraph.children {
+            visitInlineMarkup(child)
+        }
+        result += "</p>\n"
+    }
+
+    private mutating func visitText(_ text: Text) {
+        result += escapeHTML(text.string)
+    }
+
+    private mutating func visitEmphasis(_ emphasis: Emphasis) {
+        result += "<em>"
+        for child in emphasis.children {
+            visitInlineMarkup(child)
+        }
+        result += "</em>"
+    }
+
+    private mutating func visitStrong(_ strong: Strong) {
+        result += "<strong>"
+        for child in strong.children {
+            visitInlineMarkup(child)
+        }
+        result += "</strong>"
+    }
+
+    private mutating func visitStrikethrough(_ strikethrough: Strikethrough) {
+        result += "<del>"
+        for child in strikethrough.children {
+            visitInlineMarkup(child)
+        }
+        result += "</del>"
+    }
+
+    private mutating func visitInlineCode(_ inlineCode: InlineCode) {
+        result += "<code>\(escapeHTML(inlineCode.code))</code>"
+    }
+
+    private mutating func visitCodeBlock(_ codeBlock: CodeBlock) async {
+        let language = codeBlock.language ?? ""
+
+        if !language.isEmpty {
+            result += "<pre><code class=\"language-\(escapeHTML(language))\">"
+        } else {
+            result += "<pre><code>"
+        }
+
+        if !language.isEmpty {
+            let highlighted = await highlighter.highlightToHTMLAsync(code: codeBlock.code, language: language)
+            result += highlighted
+        } else {
+            result += escapeHTML(codeBlock.code)
+        }
+
+        result += "</code></pre>\n"
+    }
+
+    private mutating func visitLink(_ link: Link) {
+        let href = link.destination ?? ""
+        result += "<a href=\"\(escapeHTML(href))\">"
+        for child in link.children {
+            visitInlineMarkup(child)
+        }
+        result += "</a>"
+    }
+
+    private mutating func visitImage(_ image: Image) {
+        let src = image.source ?? ""
+        let alt = image.plainText
+
+        var cssClass: String?
+
+        if validateImages && ImageValidator.isDataURI(src) {
+            let validationResult = ImageValidator.validate(dataURI: src)
+            switch validationResult {
+            case .valid:
+                break
+            case .mismatch, .unrecognized, .invalidData:
+                cssClass = "invalid-image"
+            }
+        }
+
+        if let cls = cssClass {
+            result += "<img class=\"\(cls)\" src=\"\(escapeHTML(src))\" alt=\"\(escapeHTML(alt))\">"
+        } else {
+            result += "<img src=\"\(escapeHTML(src))\" alt=\"\(escapeHTML(alt))\">"
+        }
+    }
+
+    private mutating func visitUnorderedList(_ unorderedList: UnorderedList) async {
+        result += "<ul>\n"
+        for child in unorderedList.children {
+            await visitMarkup(child)
+        }
+        result += "</ul>\n"
+    }
+
+    private mutating func visitOrderedList(_ orderedList: OrderedList) async {
+        result += "<ol>\n"
+        for child in orderedList.children {
+            await visitMarkup(child)
+        }
+        result += "</ol>\n"
+    }
+
+    private mutating func visitListItem(_ listItem: ListItem) {
+        if let checkbox = listItem.checkbox {
+            let checked = checkbox == .checked ? " checked" : ""
+            result += "<li><input type=\"checkbox\" disabled\(checked)> "
+        } else {
+            result += "<li>"
+        }
+        for child in listItem.children {
+            if let paragraph = child as? Paragraph {
+                for inlineChild in paragraph.children {
+                    visitInlineMarkup(inlineChild)
+                }
+            } else {
+                visitInlineMarkup(child)
+            }
+        }
+        result += "</li>\n"
+    }
+
+    private mutating func visitBlockQuote(_ blockQuote: BlockQuote) async {
+        result += "<blockquote>\n"
+        for child in blockQuote.children {
+            await visitMarkup(child)
+        }
+        result += "</blockquote>\n"
+    }
+
+    private mutating func visitThematicBreak(_ thematicBreak: ThematicBreak) {
+        result += "<hr>\n"
+    }
+
+    private mutating func visitTable(_ table: Table) {
+        result += "<table>\n"
+        let head = table.head
+        result += "<thead>\n<tr>\n"
+        for cell in head.cells {
+            result += "<th>"
+            for child in cell.children {
+                visitInlineMarkup(child)
+            }
+            result += "</th>\n"
+        }
+        result += "</tr>\n</thead>\n"
+        result += "<tbody>\n"
+        for row in table.body.rows {
+            result += "<tr>\n"
+            for cell in row.cells {
+                result += "<td>"
+                for child in cell.children {
+                    visitInlineMarkup(child)
+                }
+                result += "</td>\n"
+            }
+            result += "</tr>\n"
+        }
+        result += "</tbody>\n</table>\n"
+    }
+
+    private mutating func visitLineBreak(_ lineBreak: LineBreak) {
+        result += "<br>\n"
+    }
+
+    private mutating func visitSoftBreak(_ softBreak: SoftBreak) {
+        result += "\n"
+    }
+
+    private mutating func visitHTMLBlock(_ html: HTMLBlock) {
+        result += html.rawHTML
+    }
+
+    private mutating func visitInlineHTML(_ html: InlineHTML) {
+        result += html.rawHTML
+    }
+
+    private func escapeHTML(_ string: String) -> String {
+        string
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+    }
+}

--- a/SwiftMarkdownCore/Rendering/HTMLRenderer.swift
+++ b/SwiftMarkdownCore/Rendering/HTMLRenderer.swift
@@ -64,6 +64,25 @@ public final class HTMLRenderer: HTMLMarkdownRenderer {
         return walker.result
     }
 
+    /// Renders a Markdown document to HTML with lazy-loaded syntax highlighting.
+    ///
+    /// Use this method when you need syntax highlighting for languages other than Swift.
+    /// The highlighter will download grammars on first use and cache them permanently.
+    ///
+    /// - Parameters:
+    ///   - document: The parsed Markdown document.
+    ///   - highlighter: A lazy highlighter that can download grammars on demand.
+    /// - Returns: The rendered HTML string.
+    public func renderAsync(_ document: Document, highlighter: LazyTreeSitterHighlighter) async -> String {
+        var walker = AsyncHTMLWalker(highlighter: highlighter, validateImages: validateImages)
+        await walker.visit(document)
+
+        if wrapInDocument {
+            return wrapHTML(walker.result)
+        }
+        return walker.result
+    }
+
     private func wrapHTML(_ content: String) -> String {
         """
         <!DOCTYPE html>

--- a/SwiftMarkdownCore/SyntaxHighlighting/GrammarError.swift
+++ b/SwiftMarkdownCore/SyntaxHighlighting/GrammarError.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// Errors that can occur during grammar operations.
+public enum GrammarError: Error, LocalizedError, Equatable {
+    /// The requested grammar is not available in the manifest.
+    case unknownGrammar(String)
+
+    /// Failed to download the grammar from the remote server.
+    case downloadFailed(String, String)
+
+    /// Failed to extract the grammar tarball.
+    case extractionFailed(String, String)
+
+    /// Failed to load the dynamic library.
+    case loadFailed(String, String)
+
+    /// The tree_sitter_<lang> symbol was not found in the library.
+    case symbolNotFound(String)
+
+    /// Failed to create the cache directory.
+    case cacheDirectoryError(String)
+
+    /// Failed to parse the manifest.
+    case manifestParseError(String)
+
+    /// Network error during download.
+    case networkError(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .unknownGrammar(let language):
+            return "Unknown grammar: \(language)"
+        case .downloadFailed(let language, let reason):
+            return "Failed to download \(language) grammar: \(reason)"
+        case .extractionFailed(let language, let reason):
+            return "Failed to extract \(language) grammar: \(reason)"
+        case .loadFailed(let language, let reason):
+            return "Failed to load \(language) grammar: \(reason)"
+        case .symbolNotFound(let symbol):
+            return "Symbol not found: \(symbol)"
+        case .cacheDirectoryError(let reason):
+            return "Cache directory error: \(reason)"
+        case .manifestParseError(let reason):
+            return "Failed to parse manifest: \(reason)"
+        case .networkError(let reason):
+            return "Network error: \(reason)"
+        }
+    }
+}

--- a/SwiftMarkdownCore/SyntaxHighlighting/GrammarManager.swift
+++ b/SwiftMarkdownCore/SyntaxHighlighting/GrammarManager.swift
@@ -1,0 +1,256 @@
+import Foundation
+import SwiftTreeSitter
+
+/// A loaded grammar ready for use with tree-sitter.
+public struct LoadedGrammar: Sendable {
+    /// The tree-sitter language pointer.
+    public let language: Language
+
+    /// Path to the highlights.scm query file.
+    public let queriesURL: URL
+
+    /// The canonical name of the grammar.
+    public let name: String
+}
+
+/// Manages downloading, caching, and loading tree-sitter grammars.
+///
+/// Grammars are downloaded from GitHub releases on first use and cached
+/// permanently in `~/Library/Application Support/SwiftMarkdown/Grammars/`.
+///
+/// ## Example
+/// ```swift
+/// let manager = GrammarManager.shared
+/// if let grammar = try await manager.grammar(for: "javascript") {
+///     // Use grammar.language with tree-sitter
+/// }
+/// ```
+public actor GrammarManager {
+    /// Shared instance for the application.
+    public static let shared = GrammarManager()
+
+    // swiftlint:disable force_unwrapping
+    /// Base URL for downloading grammars from GitHub releases.
+    public static let defaultReleaseBaseURL = URL(
+        string: "https://github.com/open-cli-collective/apple-tree-sitter-grammars/releases/latest/download"
+    )!
+    // swiftlint:enable force_unwrapping
+
+    private let cacheURL: URL
+    private let releaseBaseURL: URL
+    private let urlSession: URLSession
+
+    private var manifest: GrammarManifest?
+    private var loadedGrammars: [String: LoadedGrammar] = [:]
+    private var loadingTasks: [String: Task<LoadedGrammar?, Error>] = [:]
+
+    /// Creates a grammar manager with custom configuration.
+    ///
+    /// - Parameters:
+    ///   - cacheURL: Directory for cached grammars. Defaults to Application Support.
+    ///   - releaseBaseURL: Base URL for downloading grammars.
+    ///   - urlSession: URLSession for network requests.
+    public init(
+        cacheURL: URL? = nil,
+        releaseBaseURL: URL = GrammarManager.defaultReleaseBaseURL,
+        urlSession: URLSession = .shared
+    ) {
+        self.releaseBaseURL = releaseBaseURL
+        self.urlSession = urlSession
+
+        if let cacheURL = cacheURL {
+            self.cacheURL = cacheURL
+        } else {
+            // swiftlint:disable:next force_unwrapping
+            let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+            self.cacheURL = appSupport
+                .appendingPathComponent("SwiftMarkdown")
+                .appendingPathComponent("Grammars")
+        }
+    }
+
+    // MARK: - Public API
+
+    /// Gets a grammar for the specified language, downloading if necessary.
+    ///
+    /// - Parameter language: Language identifier (e.g., "javascript", "js", "py").
+    /// - Returns: The loaded grammar, or nil if not available.
+    /// - Throws: GrammarError if download or loading fails.
+    public func grammar(for language: String) async throws -> LoadedGrammar? {
+        // Load manifest if needed
+        if manifest == nil {
+            manifest = try await loadManifest()
+        }
+
+        guard let manifest = manifest,
+              let canonical = manifest.canonicalName(for: language) else {
+            return nil
+        }
+
+        // Already loaded?
+        if let grammar = loadedGrammars[canonical] {
+            return grammar
+        }
+
+        // Already loading? Wait for existing task
+        if let task = loadingTasks[canonical] {
+            return try await task.value
+        }
+
+        // Start loading
+        let task = Task<LoadedGrammar?, Error> {
+            try await loadGrammar(canonical)
+        }
+        loadingTasks[canonical] = task
+
+        defer { loadingTasks[canonical] = nil }
+
+        let grammar = try await task.value
+        if let grammar = grammar {
+            loadedGrammars[canonical] = grammar
+        }
+        return grammar
+    }
+
+    /// Checks if a grammar is available (in manifest).
+    public func supportsLanguage(_ language: String) async -> Bool {
+        if manifest == nil {
+            manifest = try? await loadManifest()
+        }
+        return manifest?.canonicalName(for: language) != nil
+    }
+
+    /// Gets the list of all supported languages.
+    public func supportedLanguages() async -> [String] {
+        if manifest == nil {
+            manifest = try? await loadManifest()
+        }
+        return manifest?.supportedLanguages ?? []
+    }
+
+    /// Clears all cached grammars and resets state.
+    public func clearCache() throws {
+        loadedGrammars.removeAll()
+        loadingTasks.removeAll()
+        manifest = nil
+
+        if FileManager.default.fileExists(atPath: cacheURL.path) {
+            try FileManager.default.removeItem(at: cacheURL)
+        }
+    }
+
+    /// Returns the cache directory URL.
+    public var cacheDirectory: URL {
+        cacheURL
+    }
+
+    // MARK: - Private Implementation
+
+    private func loadManifest() async throws -> GrammarManifest {
+        // Try cached manifest first
+        let cachedManifestURL = cacheURL.appendingPathComponent("manifest.json")
+        if let cachedData = try? Data(contentsOf: cachedManifestURL) {
+            if let manifest = try? GrammarManifest.parse(from: cachedData) {
+                return manifest
+            }
+        }
+
+        // Download fresh manifest
+        let manifestURL = releaseBaseURL.appendingPathComponent("manifest.json")
+        let (data, response) = try await urlSession.data(from: manifestURL)
+
+        guard let httpResponse = response as? HTTPURLResponse,
+              httpResponse.statusCode == 200 else {
+            throw GrammarError.networkError("Failed to download manifest")
+        }
+
+        let manifest = try GrammarManifest.parse(from: data)
+
+        // Cache the manifest
+        try ensureCacheDirectory()
+        try data.write(to: cachedManifestURL)
+
+        return manifest
+    }
+
+    private func loadGrammar(_ name: String) async throws -> LoadedGrammar? {
+        let grammarDir = cacheURL.appendingPathComponent(name)
+        let dylibURL = grammarDir.appendingPathComponent("\(name).dylib")
+        let queriesURL = grammarDir.appendingPathComponent("queries").appendingPathComponent("highlights.scm")
+
+        // Check cache
+        if FileManager.default.fileExists(atPath: dylibURL.path) {
+            return try loadFromCache(name: name, dylibURL: dylibURL, queriesURL: queriesURL)
+        }
+
+        // Download
+        try await downloadGrammar(name, to: grammarDir)
+
+        return try loadFromCache(name: name, dylibURL: dylibURL, queriesURL: queriesURL)
+    }
+
+    private func downloadGrammar(_ name: String, to directory: URL) async throws {
+        let tarballURL = releaseBaseURL.appendingPathComponent("\(name).tar.gz")
+
+        let (tempURL, response) = try await urlSession.download(from: tarballURL)
+
+        guard let httpResponse = response as? HTTPURLResponse,
+              httpResponse.statusCode == 200 else {
+            throw GrammarError.downloadFailed(name, "HTTP \((response as? HTTPURLResponse)?.statusCode ?? 0)")
+        }
+
+        try ensureCacheDirectory()
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        // Extract tarball using tar command
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/tar")
+        process.arguments = ["-xzf", tempURL.path, "-C", directory.path]
+
+        try process.run()
+        process.waitUntilExit()
+
+        guard process.terminationStatus == 0 else {
+            throw GrammarError.extractionFailed(name, "tar exited with status \(process.terminationStatus)")
+        }
+
+        // Clean up temp file
+        try? FileManager.default.removeItem(at: tempURL)
+    }
+
+    private func loadFromCache(name: String, dylibURL: URL, queriesURL: URL) throws -> LoadedGrammar {
+        guard let handle = dlopen(dylibURL.path, RTLD_NOW) else {
+            let error = String(cString: dlerror())
+            throw GrammarError.loadFailed(name, error)
+        }
+
+        // Get tree_sitter_<name> symbol
+        let symbolName = "tree_sitter_\(name)"
+        guard let symbol = dlsym(handle, symbolName) else {
+            throw GrammarError.symbolNotFound(symbolName)
+        }
+
+        // Cast to tree-sitter language function and call it
+        typealias LanguageFunc = @convention(c) () -> OpaquePointer
+        let languageFunc = unsafeBitCast(symbol, to: LanguageFunc.self)
+        let languagePtr = languageFunc()
+
+        let language = Language(language: languagePtr)
+
+        return LoadedGrammar(
+            language: language,
+            queriesURL: queriesURL,
+            name: name
+        )
+    }
+
+    private func ensureCacheDirectory() throws {
+        if !FileManager.default.fileExists(atPath: cacheURL.path) {
+            do {
+                try FileManager.default.createDirectory(at: cacheURL, withIntermediateDirectories: true)
+            } catch {
+                throw GrammarError.cacheDirectoryError(error.localizedDescription)
+            }
+        }
+    }
+}

--- a/SwiftMarkdownCore/SyntaxHighlighting/GrammarManifest.swift
+++ b/SwiftMarkdownCore/SyntaxHighlighting/GrammarManifest.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+/// Metadata about a single grammar in the manifest.
+public struct GrammarInfo: Codable, Equatable, Sendable {
+    /// Display name for the language (e.g., "JavaScript").
+    public let displayName: String
+
+    /// Version of the grammar (e.g., "v0.23.1").
+    public let version: String
+
+    /// License type (e.g., "MIT", "Apache-2.0").
+    public let license: String
+
+    /// Alternative names for the language (e.g., ["js", "jsx"]).
+    public let aliases: [String]
+
+    /// SHA-256 checksum of the dylib file.
+    public let checksum: String
+
+    /// Size of the dylib file in bytes.
+    public let size: Int
+}
+
+/// Parsed manifest from apple-tree-sitter-grammars releases.
+///
+/// The manifest contains metadata about all available grammars,
+/// including their versions, checksums, and aliases.
+public struct GrammarManifest: Codable, Equatable, Sendable {
+    /// Manifest schema version.
+    public let version: String
+
+    /// When the manifest was generated.
+    public let generatedAt: String
+
+    /// Grammar metadata keyed by canonical name.
+    public let grammars: [String: GrammarInfo]
+
+    /// Maps a language identifier to its canonical grammar name.
+    ///
+    /// Handles aliases like "js" -> "javascript", "py" -> "python".
+    /// Returns nil if the language is not found.
+    public func canonicalName(for language: String) -> String? {
+        let lowercased = language.lowercased()
+
+        // Direct match
+        if grammars[lowercased] != nil {
+            return lowercased
+        }
+
+        // Search aliases
+        for (name, info) in grammars where info.aliases.map({ $0.lowercased() }).contains(lowercased) {
+            return name
+        }
+
+        return nil
+    }
+
+    /// Returns the grammar info for a language, resolving aliases.
+    public func grammarInfo(for language: String) -> GrammarInfo? {
+        guard let canonical = canonicalName(for: language) else {
+            return nil
+        }
+        return grammars[canonical]
+    }
+
+    /// All supported language identifiers (canonical names + aliases).
+    public var supportedLanguages: [String] {
+        var languages: [String] = []
+        for (name, info) in grammars {
+            languages.append(name)
+            languages.append(contentsOf: info.aliases)
+        }
+        return languages.sorted()
+    }
+
+    /// Parses a manifest from JSON data.
+    public static func parse(from data: Data) throws -> GrammarManifest {
+        let decoder = JSONDecoder()
+        do {
+            return try decoder.decode(GrammarManifest.self, from: data)
+        } catch {
+            throw GrammarError.manifestParseError(error.localizedDescription)
+        }
+    }
+
+    /// Parses a manifest from a JSON string.
+    public static func parse(from string: String) throws -> GrammarManifest {
+        guard let data = string.data(using: .utf8) else {
+            throw GrammarError.manifestParseError("Invalid UTF-8 string")
+        }
+        return try parse(from: data)
+    }
+}

--- a/SwiftMarkdownCore/SyntaxHighlighting/LazyTreeSitterHighlighter.swift
+++ b/SwiftMarkdownCore/SyntaxHighlighting/LazyTreeSitterHighlighter.swift
@@ -1,0 +1,316 @@
+import Foundation
+import SwiftTreeSitter
+import TreeSitterSwift
+
+/// A syntax highlighter that lazily loads grammars on demand.
+///
+/// This highlighter uses `GrammarManager` to download and cache tree-sitter
+/// grammars from GitHub releases. Swift is always available (bundled),
+/// while other languages are downloaded on first use.
+///
+/// ## Example
+/// ```swift
+/// let highlighter = LazyTreeSitterHighlighter()
+///
+/// // Async API for lazy-loaded grammars
+/// let html = await highlighter.highlightToHTMLAsync(code: jsCode, language: "javascript")
+///
+/// // Sync API falls back to plain text for non-Swift languages
+/// let html = highlighter.highlightToHTML(code: code, language: "python")  // Returns escaped code
+/// ```
+public final class LazyTreeSitterHighlighter: HTMLSyntaxHighlighter, @unchecked Sendable {
+    private let parser: Parser
+    private var swiftConfig: LanguageConfiguration?
+    private let grammarManager: GrammarManager
+    private var languageConfigs: [String: LanguageConfiguration] = [:]
+    private let configLock = NSLock()
+
+    /// Creates a new lazy highlighter.
+    ///
+    /// - Parameter grammarManager: The grammar manager to use. Defaults to shared instance.
+    public init(grammarManager: GrammarManager = .shared) {
+        self.parser = Parser()
+        self.grammarManager = grammarManager
+
+        // Initialize bundled Swift
+        do {
+            swiftConfig = try LanguageConfiguration(
+                tree_sitter_swift(),
+                name: "Swift"
+            )
+        } catch {
+            swiftConfig = nil
+        }
+    }
+
+    // MARK: - SyntaxHighlighter Protocol
+
+    public var supportedLanguages: [String] {
+        // Synchronously return only bundled languages
+        ["swift"]
+    }
+
+    public func supportsLanguage(_ language: String) -> Bool {
+        // Synchronously check only bundled languages
+        language.lowercased() == "swift"
+    }
+
+    public func highlight(code: String, language: String) -> [HighlightToken] {
+        // Synchronous method only works for Swift
+        guard language.lowercased() == "swift",
+              let config = swiftConfig,
+              let query = config.queries[.highlights] else {
+            return []
+        }
+
+        configLock.lock()
+        do {
+            try parser.setLanguage(config.language)
+        } catch {
+            configLock.unlock()
+            return []
+        }
+
+        guard let tree = parser.parse(code) else {
+            configLock.unlock()
+            return []
+        }
+
+        let tokens = extractTokens(from: tree, code: code, query: query)
+        configLock.unlock()
+        return tokens
+    }
+
+    public func highlightToHTML(code: String, language: String) -> String {
+        // Synchronous method only works for Swift
+        guard language.lowercased() == "swift" else {
+            return escapeHTML(code)
+        }
+
+        let tokens = highlight(code: code, language: language)
+        guard !tokens.isEmpty else {
+            return escapeHTML(code)
+        }
+
+        return renderTokensToHTML(code: code, tokens: tokens)
+    }
+
+    // MARK: - Async API
+
+    /// Asynchronously checks if a language is supported (includes lazy-loaded grammars).
+    public func supportsLanguageAsync(_ language: String) async -> Bool {
+        if language.lowercased() == "swift" {
+            return true
+        }
+        return await grammarManager.supportsLanguage(language)
+    }
+
+    /// Returns all supported languages including lazy-loaded ones.
+    public func supportedLanguagesAsync() async -> [String] {
+        var languages = await grammarManager.supportedLanguages()
+        if !languages.contains("swift") {
+            languages.append("swift")
+        }
+        return languages.sorted()
+    }
+
+    /// Asynchronously highlights code, downloading the grammar if needed.
+    ///
+    /// - Parameters:
+    ///   - code: The source code to highlight.
+    ///   - language: The language identifier.
+    /// - Returns: An array of highlight tokens, or empty if unsupported.
+    public func highlightAsync(code: String, language: String) async -> [HighlightToken] {
+        // Swift is always available synchronously
+        if language.lowercased() == "swift" {
+            return highlight(code: code, language: language)
+        }
+
+        // Try to load grammar
+        guard let grammar = try? await grammarManager.grammar(for: language) else {
+            return []
+        }
+
+        return await highlightWithGrammar(code: code, grammar: grammar)
+    }
+
+    /// Asynchronously highlights code to HTML, downloading the grammar if needed.
+    ///
+    /// - Parameters:
+    ///   - code: The source code to highlight.
+    ///   - language: The language identifier.
+    /// - Returns: HTML string with token spans, or escaped code if unsupported.
+    public func highlightToHTMLAsync(code: String, language: String) async -> String {
+        let tokens = await highlightAsync(code: code, language: language)
+        guard !tokens.isEmpty else {
+            return escapeHTML(code)
+        }
+        return renderTokensToHTML(code: code, tokens: tokens)
+    }
+
+    // MARK: - Private Implementation
+
+    private func highlightWithGrammar(code: String, grammar: LoadedGrammar) async -> [HighlightToken] {
+        configLock.lock()
+        defer { configLock.unlock() }
+
+        // Get or create configuration
+        let config: LanguageConfiguration
+        if let cached = languageConfigs[grammar.name] {
+            config = cached
+        } else {
+            // Load highlights.scm
+            guard FileManager.default.fileExists(atPath: grammar.queriesURL.path),
+                  let querySource = try? String(contentsOf: grammar.queriesURL) else {
+                return []
+            }
+
+            do {
+                guard let queryData = querySource.data(using: .utf8) else {
+                    return []
+                }
+                _ = try Query(language: grammar.language, data: queryData)
+                config = try LanguageConfiguration(grammar.language, name: grammar.name)
+                languageConfigs[grammar.name] = config
+            } catch {
+                return []
+            }
+        }
+
+        do {
+            try parser.setLanguage(config.language)
+        } catch {
+            return []
+        }
+
+        guard let tree = parser.parse(code),
+              let query = config.queries[.highlights] else {
+            return []
+        }
+
+        return extractTokens(from: tree, code: code, query: query)
+    }
+
+    private func extractTokens(from tree: MutableTree, code: String, query: Query) -> [HighlightToken] {
+        let cursor = query.execute(in: tree)
+        var tokens: [HighlightToken] = []
+
+        for match in cursor {
+            for capture in match.captures {
+                guard let captureName = query.captureName(for: capture.index) else {
+                    continue
+                }
+
+                let tokenType = mapCaptureToTokenType(captureName)
+                let node = capture.node
+                let byteRange = node.byteRange
+
+                guard let range = byteRangeToStringRange(byteRange, in: code) else {
+                    continue
+                }
+
+                tokens.append(HighlightToken(range: range, tokenType: tokenType))
+            }
+        }
+
+        return deduplicateAndSort(tokens)
+    }
+
+    private func byteRangeToStringRange(_ byteRange: Range<UInt32>, in string: String) -> Range<String.Index>? {
+        let utf8 = string.utf8
+        let startOffset = Int(byteRange.lowerBound)
+        let endOffset = Int(byteRange.upperBound)
+
+        guard startOffset <= utf8.count, endOffset <= utf8.count else {
+            return nil
+        }
+
+        let startIndex = utf8.index(utf8.startIndex, offsetBy: startOffset)
+        let endIndex = utf8.index(utf8.startIndex, offsetBy: endOffset)
+
+        guard let start = String.Index(startIndex, within: string),
+              let end = String.Index(endIndex, within: string) else {
+            return nil
+        }
+
+        return start..<end
+    }
+
+    private static let captureMapping: [(prefixes: [String], tokenType: HighlightToken.TokenType)] = [
+        (["keyword"], .keyword),
+        (["string"], .string),
+        (["comment"], .comment),
+        (["number", "constant.numeric"], .number),
+        (["function", "method"], .function),
+        (["type"], .type),
+        (["variable", "identifier"], .variable),
+        (["operator"], .operator),
+        (["punctuation"], .punctuation),
+        (["property", "field"], .property),
+        (["attribute"], .attribute)
+    ]
+
+    private func mapCaptureToTokenType(_ name: String) -> HighlightToken.TokenType {
+        let lowercased = name.lowercased()
+
+        guard let match = Self.captureMapping.first(where: { mapping in
+            mapping.prefixes.contains { lowercased.hasPrefix($0) }
+        }) else {
+            return .plain
+        }
+
+        return match.tokenType
+    }
+
+    private func deduplicateAndSort(_ tokens: [HighlightToken]) -> [HighlightToken] {
+        let sorted = tokens.sorted { $0.range.lowerBound < $1.range.lowerBound }
+        var result: [HighlightToken] = []
+        var lastEnd: String.Index?
+
+        for token in sorted {
+            if let end = lastEnd, token.range.lowerBound < end {
+                continue
+            }
+            result.append(token)
+            lastEnd = token.range.upperBound
+        }
+
+        return result
+    }
+
+    private func renderTokensToHTML(code: String, tokens: [HighlightToken]) -> String {
+        var result = ""
+        var currentIndex = code.startIndex
+
+        for token in tokens {
+            if currentIndex < token.range.lowerBound {
+                result += escapeHTML(String(code[currentIndex..<token.range.lowerBound]))
+            }
+
+            let tokenText = String(code[token.range])
+            if token.tokenType != .plain {
+                result += "<span class=\"token-\(token.tokenType.rawValue)\">"
+                result += escapeHTML(tokenText)
+                result += "</span>"
+            } else {
+                result += escapeHTML(tokenText)
+            }
+
+            currentIndex = token.range.upperBound
+        }
+
+        if currentIndex < code.endIndex {
+            result += escapeHTML(String(code[currentIndex...]))
+        }
+
+        return result
+    }
+
+    private func escapeHTML(_ string: String) -> String {
+        string
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+    }
+}

--- a/SwiftMarkdownTests/GrammarManagerTests.swift
+++ b/SwiftMarkdownTests/GrammarManagerTests.swift
@@ -1,0 +1,158 @@
+import XCTest
+@testable import SwiftMarkdownCore
+
+final class GrammarManagerTests: XCTestCase {
+    var tempDir: URL?
+
+    override func setUp() {
+        super.setUp()
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("GrammarManagerTests-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        tempDir = dir
+    }
+
+    override func tearDown() {
+        if let dir = tempDir {
+            try? FileManager.default.removeItem(at: dir)
+        }
+        super.tearDown()
+    }
+
+    // MARK: - Initialization Tests
+
+    func testDefaultCacheDirectory() async {
+        let manager = GrammarManager()
+        let cacheDir = await manager.cacheDirectory
+
+        XCTAssertTrue(cacheDir.path.contains("Application Support"))
+        XCTAssertTrue(cacheDir.path.contains("SwiftMarkdown"))
+        XCTAssertTrue(cacheDir.path.contains("Grammars"))
+    }
+
+    func testCustomCacheDirectory() async throws {
+        let dir = try XCTUnwrap(tempDir)
+        let customCache = dir.appendingPathComponent("custom-cache")
+        let manager = GrammarManager(cacheURL: customCache)
+        let cacheDir = await manager.cacheDirectory
+
+        XCTAssertEqual(cacheDir, customCache)
+    }
+
+    // MARK: - Cache Clear Tests
+
+    func testClearCacheRemovesDirectory() async throws {
+        let dir = try XCTUnwrap(tempDir)
+        let cacheDir = dir.appendingPathComponent("cache")
+        let manager = GrammarManager(cacheURL: cacheDir)
+
+        // Create some files in cache
+        try FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)
+        let testFile = cacheDir.appendingPathComponent("test.txt")
+        try "test".write(to: testFile, atomically: true, encoding: .utf8)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: testFile.path))
+
+        try await manager.clearCache()
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: cacheDir.path))
+    }
+
+    func testClearCacheWithNonExistentDirectory() async throws {
+        let dir = try XCTUnwrap(tempDir)
+        let cacheDir = dir.appendingPathComponent("nonexistent")
+        let manager = GrammarManager(cacheURL: cacheDir)
+
+        // Should not throw even if directory doesn't exist
+        try await manager.clearCache()
+    }
+
+    // MARK: - Error Type Tests
+
+    func testGrammarErrorDescriptions() {
+        XCTAssertEqual(
+            GrammarError.unknownGrammar("foo").errorDescription,
+            "Unknown grammar: foo"
+        )
+        XCTAssertEqual(
+            GrammarError.downloadFailed("js", "timeout").errorDescription,
+            "Failed to download js grammar: timeout"
+        )
+        XCTAssertEqual(
+            GrammarError.loadFailed("js", "bad dylib").errorDescription,
+            "Failed to load js grammar: bad dylib"
+        )
+        XCTAssertEqual(
+            GrammarError.symbolNotFound("tree_sitter_foo").errorDescription,
+            "Symbol not found: tree_sitter_foo"
+        )
+    }
+
+    func testGrammarErrorEquality() {
+        XCTAssertEqual(
+            GrammarError.unknownGrammar("foo"),
+            GrammarError.unknownGrammar("foo")
+        )
+        XCTAssertNotEqual(
+            GrammarError.unknownGrammar("foo"),
+            GrammarError.unknownGrammar("bar")
+        )
+    }
+
+    // MARK: - GrammarInfo Tests
+
+    func testGrammarInfoEquality() {
+        let info1 = GrammarInfo(
+            displayName: "JavaScript",
+            version: "v1.0.0",
+            license: "MIT",
+            aliases: ["js"],
+            checksum: "abc",
+            size: 100
+        )
+        let info2 = GrammarInfo(
+            displayName: "JavaScript",
+            version: "v1.0.0",
+            license: "MIT",
+            aliases: ["js"],
+            checksum: "abc",
+            size: 100
+        )
+
+        XCTAssertEqual(info1, info2)
+    }
+
+    func testGrammarInfoInequality() {
+        let info1 = GrammarInfo(
+            displayName: "JavaScript",
+            version: "v1.0.0",
+            license: "MIT",
+            aliases: ["js"],
+            checksum: "abc",
+            size: 100
+        )
+        let info2 = GrammarInfo(
+            displayName: "JavaScript",
+            version: "v2.0.0",  // Different version
+            license: "MIT",
+            aliases: ["js"],
+            checksum: "abc",
+            size: 100
+        )
+
+        XCTAssertNotEqual(info1, info2)
+    }
+
+    // MARK: - LoadedGrammar Tests
+
+    func testLoadedGrammarProperties() async throws {
+        // This test just verifies the LoadedGrammar struct works
+        // We can't easily create a real Language without a dylib
+        let dir = try XCTUnwrap(tempDir)
+        let queriesURL = dir.appendingPathComponent("queries/highlights.scm")
+
+        // Just verify the struct compiles and works
+        // Full integration testing requires actual grammars
+        XCTAssertTrue(queriesURL.lastPathComponent == "highlights.scm")
+    }
+}

--- a/SwiftMarkdownTests/GrammarManifestTests.swift
+++ b/SwiftMarkdownTests/GrammarManifestTests.swift
@@ -1,0 +1,248 @@
+import XCTest
+@testable import SwiftMarkdownCore
+
+final class GrammarManifestTests: XCTestCase {
+    // MARK: - Parsing Tests
+
+    func testParseValidManifest() throws {
+        let json = """
+        {
+            "version": "1.0.0",
+            "generatedAt": "2026-01-29T12:00:00Z",
+            "grammars": {
+                "javascript": {
+                    "displayName": "JavaScript",
+                    "version": "v0.23.1",
+                    "license": "MIT",
+                    "aliases": ["js", "jsx"],
+                    "checksum": "abc123",
+                    "size": 791664
+                }
+            }
+        }
+        """
+
+        let manifest = try GrammarManifest.parse(from: json)
+
+        XCTAssertEqual(manifest.version, "1.0.0")
+        XCTAssertEqual(manifest.generatedAt, "2026-01-29T12:00:00Z")
+        XCTAssertEqual(manifest.grammars.count, 1)
+
+        let jsInfo = manifest.grammars["javascript"]
+        XCTAssertNotNil(jsInfo)
+        XCTAssertEqual(jsInfo?.displayName, "JavaScript")
+        XCTAssertEqual(jsInfo?.version, "v0.23.1")
+        XCTAssertEqual(jsInfo?.license, "MIT")
+        XCTAssertEqual(jsInfo?.aliases, ["js", "jsx"])
+        XCTAssertEqual(jsInfo?.checksum, "abc123")
+        XCTAssertEqual(jsInfo?.size, 791664)
+    }
+
+    func testParseMultipleGrammars() throws {
+        let json = """
+        {
+            "version": "1.0.0",
+            "generatedAt": "2026-01-29T12:00:00Z",
+            "grammars": {
+                "javascript": {
+                    "displayName": "JavaScript",
+                    "version": "v0.23.1",
+                    "license": "MIT",
+                    "aliases": ["js"],
+                    "checksum": "abc",
+                    "size": 100
+                },
+                "python": {
+                    "displayName": "Python",
+                    "version": "v0.23.6",
+                    "license": "MIT",
+                    "aliases": ["py"],
+                    "checksum": "def",
+                    "size": 200
+                }
+            }
+        }
+        """
+
+        let manifest = try GrammarManifest.parse(from: json)
+
+        XCTAssertEqual(manifest.grammars.count, 2)
+        XCTAssertNotNil(manifest.grammars["javascript"])
+        XCTAssertNotNil(manifest.grammars["python"])
+    }
+
+    func testParseEmptyGrammars() throws {
+        let json = """
+        {
+            "version": "1.0.0",
+            "generatedAt": "2026-01-29T12:00:00Z",
+            "grammars": {}
+        }
+        """
+
+        let manifest = try GrammarManifest.parse(from: json)
+
+        XCTAssertEqual(manifest.grammars.count, 0)
+    }
+
+    func testParseInvalidJSON() {
+        let invalidJSON = "not valid json"
+
+        XCTAssertThrowsError(try GrammarManifest.parse(from: invalidJSON)) { error in
+            if case GrammarError.manifestParseError = error {
+                // Expected error
+            } else {
+                XCTFail("Expected manifestParseError, got \(error)")
+            }
+        }
+    }
+
+    func testParseMissingRequiredField() {
+        let json = """
+        {
+            "version": "1.0.0"
+        }
+        """
+
+        XCTAssertThrowsError(try GrammarManifest.parse(from: json))
+    }
+
+    // MARK: - Canonical Name Tests
+
+    func testCanonicalNameDirectMatch() throws {
+        let manifest = try makeManifest(grammars: [
+            "javascript": GrammarInfo(
+                displayName: "JavaScript",
+                version: "v1.0.0",
+                license: "MIT",
+                aliases: ["js"],
+                checksum: "abc",
+                size: 100
+            )
+        ])
+
+        XCTAssertEqual(manifest.canonicalName(for: "javascript"), "javascript")
+    }
+
+    func testCanonicalNameAlias() throws {
+        let manifest = try makeManifest(grammars: [
+            "javascript": GrammarInfo(
+                displayName: "JavaScript",
+                version: "v1.0.0",
+                license: "MIT",
+                aliases: ["js", "jsx"],
+                checksum: "abc",
+                size: 100
+            )
+        ])
+
+        XCTAssertEqual(manifest.canonicalName(for: "js"), "javascript")
+        XCTAssertEqual(manifest.canonicalName(for: "jsx"), "javascript")
+    }
+
+    func testCanonicalNameCaseInsensitive() throws {
+        let manifest = try makeManifest(grammars: [
+            "javascript": GrammarInfo(
+                displayName: "JavaScript",
+                version: "v1.0.0",
+                license: "MIT",
+                aliases: ["js"],
+                checksum: "abc",
+                size: 100
+            )
+        ])
+
+        XCTAssertEqual(manifest.canonicalName(for: "JavaScript"), "javascript")
+        XCTAssertEqual(manifest.canonicalName(for: "JAVASCRIPT"), "javascript")
+        XCTAssertEqual(manifest.canonicalName(for: "JS"), "javascript")
+    }
+
+    func testCanonicalNameNotFound() throws {
+        let manifest = try makeManifest(grammars: [:])
+
+        XCTAssertNil(manifest.canonicalName(for: "unknown"))
+    }
+
+    // MARK: - Grammar Info Tests
+
+    func testGrammarInfoDirectMatch() throws {
+        let jsInfo = GrammarInfo(
+            displayName: "JavaScript",
+            version: "v1.0.0",
+            license: "MIT",
+            aliases: ["js"],
+            checksum: "abc",
+            size: 100
+        )
+        let manifest = try makeManifest(grammars: ["javascript": jsInfo])
+
+        XCTAssertEqual(manifest.grammarInfo(for: "javascript"), jsInfo)
+    }
+
+    func testGrammarInfoViaAlias() throws {
+        let jsInfo = GrammarInfo(
+            displayName: "JavaScript",
+            version: "v1.0.0",
+            license: "MIT",
+            aliases: ["js"],
+            checksum: "abc",
+            size: 100
+        )
+        let manifest = try makeManifest(grammars: ["javascript": jsInfo])
+
+        XCTAssertEqual(manifest.grammarInfo(for: "js"), jsInfo)
+    }
+
+    func testGrammarInfoNotFound() throws {
+        let manifest = try makeManifest(grammars: [:])
+
+        XCTAssertNil(manifest.grammarInfo(for: "unknown"))
+    }
+
+    // MARK: - Supported Languages Tests
+
+    func testSupportedLanguages() throws {
+        let manifest = try makeManifest(grammars: [
+            "javascript": GrammarInfo(
+                displayName: "JavaScript",
+                version: "v1.0.0",
+                license: "MIT",
+                aliases: ["js", "jsx"],
+                checksum: "abc",
+                size: 100
+            ),
+            "python": GrammarInfo(
+                displayName: "Python",
+                version: "v1.0.0",
+                license: "MIT",
+                aliases: ["py"],
+                checksum: "def",
+                size: 200
+            )
+        ])
+
+        let supported = manifest.supportedLanguages
+
+        XCTAssertTrue(supported.contains("javascript"))
+        XCTAssertTrue(supported.contains("js"))
+        XCTAssertTrue(supported.contains("jsx"))
+        XCTAssertTrue(supported.contains("python"))
+        XCTAssertTrue(supported.contains("py"))
+    }
+
+    func testSupportedLanguagesEmpty() throws {
+        let manifest = try makeManifest(grammars: [:])
+
+        XCTAssertTrue(manifest.supportedLanguages.isEmpty)
+    }
+
+    // MARK: - Helpers
+
+    private func makeManifest(grammars: [String: GrammarInfo]) throws -> GrammarManifest {
+        GrammarManifest(
+            version: "1.0.0",
+            generatedAt: "2026-01-29T12:00:00Z",
+            grammars: grammars
+        )
+    }
+}

--- a/integration-tests.md
+++ b/integration-tests.md
@@ -1,0 +1,200 @@
+# Integration Tests
+
+Manual integration tests for verifying the lazy-loading grammar system works correctly end-to-end.
+
+## Prerequisites
+
+- macOS 13.0+ (Ventura)
+- Internet connection (for first-time grammar downloads)
+- Built SwiftMarkdown app
+
+## Test Scenarios
+
+### 1. Fresh Install Flow
+
+**Purpose:** Verify grammars download correctly on first use.
+
+**Steps:**
+1. Clear grammar cache: `rm -rf ~/Library/Application\ Support/SwiftMarkdown/Grammars/`
+2. Build and run SwiftMarkdown
+3. Open a markdown file containing:
+   ```markdown
+   # Test
+
+   ```javascript
+   const greeting = "Hello";
+   console.log(greeting);
+   ```
+   ```
+4. Observe the code block
+
+**Expected:**
+- Brief delay on first render (grammar downloading)
+- JavaScript code is syntax highlighted after download
+- Cache directory created at `~/Library/Application Support/SwiftMarkdown/Grammars/javascript/`
+
+**Verification:**
+```bash
+ls -la ~/Library/Application\ Support/SwiftMarkdown/Grammars/javascript/
+# Should show: javascript.dylib, queries/highlights.scm
+```
+
+---
+
+### 2. Cache Hit Flow
+
+**Purpose:** Verify cached grammars are used without network requests.
+
+**Steps:**
+1. Complete Test 1 (JavaScript grammar cached)
+2. Disconnect from internet
+3. Open a markdown file with JavaScript code block
+4. Observe rendering
+
+**Expected:**
+- Immediate syntax highlighting
+- No network errors
+- Code renders correctly
+
+---
+
+### 3. Swift Always Available
+
+**Purpose:** Verify bundled Swift highlighting works without internet.
+
+**Steps:**
+1. Clear grammar cache
+2. Disconnect from internet
+3. Open a markdown file with Swift code block:
+   ```markdown
+   ```swift
+   let greeting = "Hello"
+   print(greeting)
+   ```
+   ```
+
+**Expected:**
+- Swift code is highlighted immediately
+- No network requests
+- Keywords, strings, etc. are colored
+
+---
+
+### 4. Unknown Language Fallback
+
+**Purpose:** Verify unknown languages render as plain text without crashing.
+
+**Steps:**
+1. Open a markdown file with:
+   ```markdown
+   ```unknownlanguage
+   this is unknown code
+   ```
+   ```
+
+**Expected:**
+- Code renders as plain text (no colors)
+- No crash or error
+- Code is properly escaped
+
+---
+
+### 5. Multiple Languages
+
+**Purpose:** Verify multiple grammars can be loaded and used together.
+
+**Steps:**
+1. Clear grammar cache
+2. Open a markdown file with multiple code blocks:
+   ```markdown
+   ```javascript
+   const x = 1;
+   ```
+
+   ```python
+   x = 1
+   ```
+
+   ```swift
+   let x = 1
+   ```
+   ```
+
+**Expected:**
+- All three languages are highlighted
+- JavaScript and Python download sequentially
+- Swift works immediately (bundled)
+- Each uses appropriate colors for its language
+
+---
+
+### 6. Network Failure Graceful Degradation
+
+**Purpose:** Verify network failures don't break rendering.
+
+**Steps:**
+1. Clear grammar cache
+2. Block network access to GitHub (e.g., hosts file or firewall)
+3. Open a markdown file with Python code block
+
+**Expected:**
+- Python code renders as plain text
+- No crash or hang
+- Rest of document renders normally
+
+---
+
+### 7. Architecture Verification
+
+**Purpose:** Verify universal binaries work on both architectures.
+
+**Steps (Apple Silicon):**
+1. Build and run on Apple Silicon Mac
+2. Download JavaScript grammar
+3. Verify highlighting works
+4. Check binary: `file ~/Library/Application\ Support/SwiftMarkdown/Grammars/javascript/javascript.dylib`
+
+**Steps (Intel):**
+1. Build and run on Intel Mac (or via Rosetta)
+2. Repeat above
+
+**Expected:**
+- Binary shows: `Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit dynamically linked shared library x86_64] [arm64]`
+- Highlighting works on both architectures
+
+---
+
+### 8. Manifest Caching
+
+**Purpose:** Verify manifest is cached and updated correctly.
+
+**Steps:**
+1. Clear grammar cache
+2. Download any grammar
+3. Check manifest: `cat ~/Library/Application\ Support/SwiftMarkdown/Grammars/manifest.json | head`
+4. Close app
+5. Reopen app and download different grammar
+
+**Expected:**
+- Manifest is cached
+- Contains grammar metadata
+- Second download uses cached manifest
+
+---
+
+## Environment Requirements
+
+| Requirement | Test Scenarios |
+|-------------|---------------|
+| Internet connection | 1, 5 |
+| No internet | 2, 3, 6 |
+| Apple Silicon | 7 |
+| Intel Mac | 7 |
+| Fresh cache | 1, 3, 5, 6, 8 |
+
+## Notes
+
+- Grammar cache is permanent (no auto-expiration)
+- Swift is always bundled (no download needed)
+- All 36 languages supported via lazy-loading
+- Grammars are universal binaries (arm64 + x86_64)


### PR DESCRIPTION
## Summary
- Implements Phase 2 of the lazy-loading syntax highlighting system
- GrammarManager actor downloads, caches, and loads tree-sitter grammars on demand
- Grammars cached permanently in `~/Library/Application Support/SwiftMarkdown/Grammars/`
- LazyTreeSitterHighlighter provides async API for grammar-based highlighting
- AsyncHTMLWalker handles async code block rendering
- Added integration test documentation for manual testing

## Test plan
- [x] Unit tests pass (135 tests, 0 failures)
- [x] Swiftlint passes (0 violations)
- [ ] CI passes
- [ ] Manual integration testing (see integration-tests.md)

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)