### PR TITLE
refactor: Use defer for lock/unlock in LazyTreeSitterHighlighter

### DIFF
--- a/SwiftMarkdownCore/SyntaxHighlighting/LazyTreeSitterHighlighter.swift
+++ b/SwiftMarkdownCore/SyntaxHighlighting/LazyTreeSitterHighlighter.swift
@@ -64,21 +64,19 @@ public final class LazyTreeSitterHighlighter: HTMLSyntaxHighlighter, @unchecked 
         }
 
         configLock.lock()
+        defer { configLock.unlock() }
+
         do {
             try parser.setLanguage(config.language)
         } catch {
-            configLock.unlock()
             return []
         }
 
         guard let tree = parser.parse(code) else {
-            configLock.unlock()
             return []
         }
 
-        let tokens = extractTokens(from: tree, code: code, query: query)
-        configLock.unlock()
-        return tokens
+        return extractTokens(from: tree, code: code, query: query)
     }
 
     public func highlightToHTML(code: String, language: String) -> String {


### PR DESCRIPTION
## Summary
- Replace manual lock/unlock pattern with `defer { configLock.unlock() }`
- Prevents potential deadlocks if code is modified later
- Matches the pattern already used in `highlightWithGrammar()`

## Test plan
- [x] All 150 tests pass
- [x] Swiftlint passes
- [ ] CI passes

Closes #22