### PR TITLE
refactor: simplify image validation with isValid property

### DIFF
--- a/SwiftMarkdownCore/ImageValidation/ImageValidator.swift
+++ b/SwiftMarkdownCore/ImageValidation/ImageValidator.swift
@@ -11,6 +11,12 @@ public enum ImageValidationResult: Equatable {
     case unrecognized
     /// The data could not be decoded (e.g., invalid base64).
     case invalidData
+
+    /// Returns true if the validation result indicates a valid image.
+    public var isValid: Bool {
+        if case .valid = self { return true }
+        return false
+    }
 }
 
 /// Validates embedded images in data URIs by checking magic bytes.

--- a/SwiftMarkdownCore/Rendering/AsyncHTMLWalker.swift
+++ b/SwiftMarkdownCore/Rendering/AsyncHTMLWalker.swift
@@ -178,11 +178,7 @@ struct AsyncHTMLWalker {
         var cssClass: String?
 
         if validateImages && ImageValidator.isDataURI(src) {
-            let validationResult = ImageValidator.validate(dataURI: src)
-            switch validationResult {
-            case .valid:
-                break
-            case .mismatch, .unrecognized, .invalidData:
+            if !ImageValidator.validate(dataURI: src).isValid {
                 cssClass = "invalid-image"
             }
         }

--- a/SwiftMarkdownCore/Rendering/HTMLRenderer.swift
+++ b/SwiftMarkdownCore/Rendering/HTMLRenderer.swift
@@ -204,11 +204,7 @@ struct HTMLWalker: MarkupWalker {
 
         // Validate data URI images if enabled
         if validateImages && ImageValidator.isDataURI(src) {
-            let validationResult = ImageValidator.validate(dataURI: src)
-            switch validationResult {
-            case .valid:
-                break // Image is valid, no special class needed
-            case .mismatch, .unrecognized, .invalidData:
+            if !ImageValidator.validate(dataURI: src).isValid {
                 cssClass = "invalid-image"
             }
         }

--- a/SwiftMarkdownTests/ImageValidatorTests.swift
+++ b/SwiftMarkdownTests/ImageValidatorTests.swift
@@ -154,6 +154,32 @@ final class ImageValidatorTests: XCTestCase {
         }
     }
 
+    // MARK: - isValid Property
+
+    func testIsValidPropertyForValidResult() {
+        let pngBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+        let dataURI = "data:image/png;base64,\(pngBase64)"
+        let result = ImageValidator.validate(dataURI: dataURI)
+        XCTAssertTrue(result.isValid)
+    }
+
+    func testIsValidPropertyForMismatch() {
+        let pngBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+        let dataURI = "data:image/jpeg;base64,\(pngBase64)"
+        let result = ImageValidator.validate(dataURI: dataURI)
+        XCTAssertFalse(result.isValid)
+    }
+
+    func testIsValidPropertyForUnrecognized() {
+        let result = ImageValidationResult.unrecognized
+        XCTAssertFalse(result.isValid)
+    }
+
+    func testIsValidPropertyForInvalidData() {
+        let result = ImageValidationResult.invalidData
+        XCTAssertFalse(result.isValid)
+    }
+
     // MARK: - HTMLRenderer Integration
 
     func testHTMLRendererWithValidationDisabled() {


### PR DESCRIPTION
## Summary
- Add `isValid` computed property to `ImageValidationResult` enum
- Simplify image validation checks in `HTMLRenderer` and `AsyncHTMLWalker` from verbose switch statements to simple `.isValid` boolean checks
- Add unit tests for the new `isValid` property covering all enum cases

## Changes
- `ImageValidator.swift`: Added `isValid` computed property
- `HTMLRenderer.swift`: Simplified validation check using `.isValid`
- `AsyncHTMLWalker.swift`: Simplified validation check using `.isValid`
- `ImageValidatorTests.swift`: Added 4 tests for `isValid` property

Closes #23