### PR TITLE
refactor: extract shared tree-sitter logic to TreeSitterTokenProcessor

### DIFF
--- a/SwiftMarkdown.xcodeproj/project.pbxproj
+++ b/SwiftMarkdown.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		CBEBB2FA9092AD797D0FF830 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1D5E5838A8AEC4E0FDC523A2 /* Assets.xcassets */; };
 		D35E9EA520E2F843B036FE55 /* SwiftMarkdownCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 95F447A42C55828BB50C30B5 /* SwiftMarkdownCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		DCA77A3E20FB950CDEBA1EAE /* LanguagesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E51AFAE35D9D543BD08E09 /* LanguagesViewModel.swift */; };
+		E7D3884E4639CDCC92F60336 /* TreeSitterTokenProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF604651588D4469963B07EA /* TreeSitterTokenProcessor.swift */; };
 		EDB84B1B268301165FBDCB45 /* HTMLRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0732F7FFFF2CB2CA3AAF34 /* HTMLRendererTests.swift */; };
 		F3C0DBD72E43F100AE91CECE /* SyntaxHighlighter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0870ADD570D5EF2C00DA1C40 /* SyntaxHighlighter.swift */; };
 		F6E7533793D2B14E0BD4DF7F /* PlainTextRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09AA4F3A79326A0FCC93CA54 /* PlainTextRenderer.swift */; };
@@ -141,6 +142,7 @@
 		E8CB32C563CC962698340BF8 /* LazyTreeSitterHighlighter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyTreeSitterHighlighter.swift; sourceTree = "<group>"; };
 		F4E51AFAE35D9D543BD08E09 /* LanguagesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguagesViewModel.swift; sourceTree = "<group>"; };
 		F60124B861E67B3E2919B216 /* ImageValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageValidatorTests.swift; sourceTree = "<group>"; };
+		FF604651588D4469963B07EA /* TreeSitterTokenProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreeSitterTokenProcessor.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -252,6 +254,7 @@
 				E8CB32C563CC962698340BF8 /* LazyTreeSitterHighlighter.swift */,
 				0870ADD570D5EF2C00DA1C40 /* SyntaxHighlighter.swift */,
 				E0CDD889C6D996E0721E08B1 /* TreeSitterHighlighter.swift */,
+				FF604651588D4469963B07EA /* TreeSitterTokenProcessor.swift */,
 			);
 			path = SyntaxHighlighting;
 			sourceTree = "<group>";
@@ -515,6 +518,7 @@
 				F3C0DBD72E43F100AE91CECE /* SyntaxHighlighter.swift in Sources */,
 				0E5BC65A4C34D2C20A13C184 /* SyntaxTheme.swift in Sources */,
 				5DEBE8F448112FD03EE248BD /* TreeSitterHighlighter.swift in Sources */,
+				E7D3884E4639CDCC92F60336 /* TreeSitterTokenProcessor.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SwiftMarkdownCore/SyntaxHighlighting/LazyTreeSitterHighlighter.swift
+++ b/SwiftMarkdownCore/SyntaxHighlighting/LazyTreeSitterHighlighter.swift
@@ -76,7 +76,7 @@ public final class LazyTreeSitterHighlighter: HTMLSyntaxHighlighter, @unchecked 
             return []
         }
 
-        return extractTokens(from: tree, code: code, query: query)
+        return TreeSitterTokenProcessor.extractTokens(from: tree, code: code, query: query)
     }
 
     public func highlightToHTML(code: String, language: String) -> String {
@@ -90,7 +90,7 @@ public final class LazyTreeSitterHighlighter: HTMLSyntaxHighlighter, @unchecked 
             return code.htmlEscaped
         }
 
-        return renderTokensToHTML(code: code, tokens: tokens)
+        return TreeSitterTokenProcessor.renderTokensToHTML(code: code, tokens: tokens)
     }
 
     // MARK: - Async API
@@ -143,7 +143,7 @@ public final class LazyTreeSitterHighlighter: HTMLSyntaxHighlighter, @unchecked 
         guard !tokens.isEmpty else {
             return code.htmlEscaped
         }
-        return renderTokensToHTML(code: code, tokens: tokens)
+        return TreeSitterTokenProcessor.renderTokensToHTML(code: code, tokens: tokens)
     }
 
     // MARK: - Private Implementation
@@ -186,121 +186,6 @@ public final class LazyTreeSitterHighlighter: HTMLSyntaxHighlighter, @unchecked 
             return []
         }
 
-        return extractTokens(from: tree, code: code, query: query)
-    }
-
-    private func extractTokens(from tree: MutableTree, code: String, query: Query) -> [HighlightToken] {
-        let cursor = query.execute(in: tree)
-        var tokens: [HighlightToken] = []
-
-        for match in cursor {
-            for capture in match.captures {
-                guard let captureName = query.captureName(for: capture.index) else {
-                    continue
-                }
-
-                let tokenType = mapCaptureToTokenType(captureName)
-                let node = capture.node
-                let byteRange = node.byteRange
-
-                guard let range = byteRangeToStringRange(byteRange, in: code) else {
-                    continue
-                }
-
-                tokens.append(HighlightToken(range: range, tokenType: tokenType))
-            }
-        }
-
-        return deduplicateAndSort(tokens)
-    }
-
-    private func byteRangeToStringRange(_ byteRange: Range<UInt32>, in string: String) -> Range<String.Index>? {
-        let utf8 = string.utf8
-        let startOffset = Int(byteRange.lowerBound)
-        let endOffset = Int(byteRange.upperBound)
-
-        guard startOffset <= utf8.count, endOffset <= utf8.count else {
-            return nil
-        }
-
-        let startIndex = utf8.index(utf8.startIndex, offsetBy: startOffset)
-        let endIndex = utf8.index(utf8.startIndex, offsetBy: endOffset)
-
-        guard let start = String.Index(startIndex, within: string),
-              let end = String.Index(endIndex, within: string) else {
-            return nil
-        }
-
-        return start..<end
-    }
-
-    private static let captureMapping: [(prefixes: [String], tokenType: HighlightToken.TokenType)] = [
-        (["keyword"], .keyword),
-        (["string"], .string),
-        (["comment"], .comment),
-        (["number", "constant.numeric"], .number),
-        (["function", "method"], .function),
-        (["type"], .type),
-        (["variable", "identifier"], .variable),
-        (["operator"], .operator),
-        (["punctuation"], .punctuation),
-        (["property", "field"], .property),
-        (["attribute"], .attribute)
-    ]
-
-    private func mapCaptureToTokenType(_ name: String) -> HighlightToken.TokenType {
-        let lowercased = name.lowercased()
-
-        guard let match = Self.captureMapping.first(where: { mapping in
-            mapping.prefixes.contains { lowercased.hasPrefix($0) }
-        }) else {
-            return .plain
-        }
-
-        return match.tokenType
-    }
-
-    private func deduplicateAndSort(_ tokens: [HighlightToken]) -> [HighlightToken] {
-        let sorted = tokens.sorted { $0.range.lowerBound < $1.range.lowerBound }
-        var result: [HighlightToken] = []
-        var lastEnd: String.Index?
-
-        for token in sorted {
-            if let end = lastEnd, token.range.lowerBound < end {
-                continue
-            }
-            result.append(token)
-            lastEnd = token.range.upperBound
-        }
-
-        return result
-    }
-
-    private func renderTokensToHTML(code: String, tokens: [HighlightToken]) -> String {
-        var result = ""
-        var currentIndex = code.startIndex
-
-        for token in tokens {
-            if currentIndex < token.range.lowerBound {
-                result += String(code[currentIndex..<token.range.lowerBound]).htmlEscaped
-            }
-
-            let tokenText = String(code[token.range])
-            if token.tokenType != .plain {
-                result += "<span class=\"token-\(token.tokenType.rawValue)\">"
-                result += tokenText.htmlEscaped
-                result += "</span>"
-            } else {
-                result += tokenText.htmlEscaped
-            }
-
-            currentIndex = token.range.upperBound
-        }
-
-        if currentIndex < code.endIndex {
-            result += String(code[currentIndex...]).htmlEscaped
-        }
-
-        return result
+        return TreeSitterTokenProcessor.extractTokens(from: tree, code: code, query: query)
     }
 }

--- a/SwiftMarkdownCore/SyntaxHighlighting/TreeSitterHighlighter.swift
+++ b/SwiftMarkdownCore/SyntaxHighlighting/TreeSitterHighlighter.swift
@@ -51,7 +51,7 @@ public final class TreeSitterHighlighter: HTMLSyntaxHighlighter, @unchecked Send
             return []
         }
 
-        return extractTokens(from: tree, code: code, query: query)
+        return TreeSitterTokenProcessor.extractTokens(from: tree, code: code, query: query)
     }
 
     public func highlightToHTML(code: String, language: String) -> String {
@@ -64,134 +64,6 @@ public final class TreeSitterHighlighter: HTMLSyntaxHighlighter, @unchecked Send
             return code.htmlEscaped
         }
 
-        return renderTokensToHTML(code: code, tokens: tokens)
-    }
-
-    // MARK: - Private
-
-    private func extractTokens(from tree: MutableTree, code: String, query: Query) -> [HighlightToken] {
-        let cursor = query.execute(in: tree)
-        var tokens: [HighlightToken] = []
-
-        for match in cursor {
-            for capture in match.captures {
-                guard let captureName = query.captureName(for: capture.index) else {
-                    continue
-                }
-
-                let tokenType = mapCaptureToTokenType(captureName)
-                let node = capture.node
-                let byteRange = node.byteRange
-
-                // Convert byte range to string indices
-                guard let range = byteRangeToStringRange(byteRange, in: code) else {
-                    continue
-                }
-
-                tokens.append(HighlightToken(range: range, tokenType: tokenType))
-            }
-        }
-
-        // Sort by range start and remove overlaps (prefer longer matches)
-        return deduplicateAndSort(tokens)
-    }
-
-    private func byteRangeToStringRange(_ byteRange: Range<UInt32>, in string: String) -> Range<String.Index>? {
-        let utf8 = string.utf8
-        let startOffset = Int(byteRange.lowerBound)
-        let endOffset = Int(byteRange.upperBound)
-
-        guard startOffset <= utf8.count, endOffset <= utf8.count else {
-            return nil
-        }
-
-        let startIndex = utf8.index(utf8.startIndex, offsetBy: startOffset)
-        let endIndex = utf8.index(utf8.startIndex, offsetBy: endOffset)
-
-        // Convert UTF-8 indices to String.Index
-        guard let start = String.Index(startIndex, within: string),
-              let end = String.Index(endIndex, within: string) else {
-            return nil
-        }
-
-        return start..<end
-    }
-
-    /// Mapping of tree-sitter capture name prefixes to token types.
-    private static let captureMapping: [(prefixes: [String], tokenType: HighlightToken.TokenType)] = [
-        (["keyword"], .keyword),
-        (["string"], .string),
-        (["comment"], .comment),
-        (["number", "constant.numeric"], .number),
-        (["function", "method"], .function),
-        (["type"], .type),
-        (["variable", "identifier"], .variable),
-        (["operator"], .operator),
-        (["punctuation"], .punctuation),
-        (["property", "field"], .property),
-        (["attribute"], .attribute)
-    ]
-
-    private func mapCaptureToTokenType(_ name: String) -> HighlightToken.TokenType {
-        let lowercased = name.lowercased()
-
-        guard let match = Self.captureMapping.first(where: { mapping in
-            mapping.prefixes.contains { lowercased.hasPrefix($0) }
-        }) else {
-            return .plain
-        }
-
-        return match.tokenType
-    }
-
-    private func deduplicateAndSort(_ tokens: [HighlightToken]) -> [HighlightToken] {
-        // Sort by start position
-        let sorted = tokens.sorted { $0.range.lowerBound < $1.range.lowerBound }
-
-        // Remove overlapping tokens (keep the first one in sorted order)
-        var result: [HighlightToken] = []
-        var lastEnd: String.Index?
-
-        for token in sorted {
-            if let end = lastEnd, token.range.lowerBound < end {
-                // This token overlaps with the previous one, skip it
-                continue
-            }
-            result.append(token)
-            lastEnd = token.range.upperBound
-        }
-
-        return result
-    }
-
-    private func renderTokensToHTML(code: String, tokens: [HighlightToken]) -> String {
-        var result = ""
-        var currentIndex = code.startIndex
-
-        for token in tokens {
-            // Add any unhighlighted text before this token
-            if currentIndex < token.range.lowerBound {
-                result += String(code[currentIndex..<token.range.lowerBound]).htmlEscaped
-            }
-
-            // Add the highlighted token
-            let tokenText = String(code[token.range])
-            if token.tokenType != .plain {
-                result += "<span class=\"token-\(token.tokenType.rawValue)\">"
-                result += tokenText.htmlEscaped
-                result += "</span>"
-            } else {
-                result += tokenText.htmlEscaped
-            }
-
-            currentIndex = token.range.upperBound
-        }
-
-        // Add any remaining text after the last token
-        if currentIndex < code.endIndex {
-            result += String(code[currentIndex...]).htmlEscaped
-        }
-
-        return result
+        return TreeSitterTokenProcessor.renderTokensToHTML(code: code, tokens: tokens)
     }
 }

--- a/SwiftMarkdownCore/SyntaxHighlighting/TreeSitterTokenProcessor.swift
+++ b/SwiftMarkdownCore/SyntaxHighlighting/TreeSitterTokenProcessor.swift
@@ -1,0 +1,129 @@
+import Foundation
+import SwiftTreeSitter
+
+/// Shared utilities for processing tree-sitter tokens into highlighted HTML.
+///
+/// Used by both `TreeSitterHighlighter` (synchronous) and `LazyTreeSitterHighlighter` (async)
+/// to avoid code duplication.
+enum TreeSitterTokenProcessor {
+    /// Mapping of tree-sitter capture name prefixes to token types.
+    private static let captureMapping: [(prefixes: [String], tokenType: HighlightToken.TokenType)] = [
+        (["keyword"], .keyword),
+        (["string"], .string),
+        (["comment"], .comment),
+        (["number", "constant.numeric"], .number),
+        (["function", "method"], .function),
+        (["type"], .type),
+        (["variable", "identifier"], .variable),
+        (["operator"], .operator),
+        (["punctuation"], .punctuation),
+        (["property", "field"], .property),
+        (["attribute"], .attribute)
+    ]
+
+    /// Extracts highlight tokens from a parsed tree using a highlight query.
+    static func extractTokens(from tree: MutableTree, code: String, query: Query) -> [HighlightToken] {
+        let cursor = query.execute(in: tree)
+        var tokens: [HighlightToken] = []
+
+        for match in cursor {
+            for capture in match.captures {
+                guard let captureName = query.captureName(for: capture.index) else {
+                    continue
+                }
+
+                let tokenType = mapCaptureToTokenType(captureName)
+                let node = capture.node
+                let byteRange = node.byteRange
+
+                guard let range = byteRangeToStringRange(byteRange, in: code) else {
+                    continue
+                }
+
+                tokens.append(HighlightToken(range: range, tokenType: tokenType))
+            }
+        }
+
+        return deduplicateAndSort(tokens)
+    }
+
+    /// Converts a byte range from tree-sitter to a Swift String.Index range.
+    static func byteRangeToStringRange(_ byteRange: Range<UInt32>, in string: String) -> Range<String.Index>? {
+        let utf8 = string.utf8
+        let startOffset = Int(byteRange.lowerBound)
+        let endOffset = Int(byteRange.upperBound)
+
+        guard startOffset <= utf8.count, endOffset <= utf8.count else {
+            return nil
+        }
+
+        let startIndex = utf8.index(utf8.startIndex, offsetBy: startOffset)
+        let endIndex = utf8.index(utf8.startIndex, offsetBy: endOffset)
+
+        guard let start = String.Index(startIndex, within: string),
+              let end = String.Index(endIndex, within: string) else {
+            return nil
+        }
+
+        return start..<end
+    }
+
+    /// Maps a tree-sitter capture name to a token type.
+    static func mapCaptureToTokenType(_ name: String) -> HighlightToken.TokenType {
+        let lowercased = name.lowercased()
+
+        guard let match = captureMapping.first(where: { mapping in
+            mapping.prefixes.contains { lowercased.hasPrefix($0) }
+        }) else {
+            return .plain
+        }
+
+        return match.tokenType
+    }
+
+    /// Sorts tokens by position and removes overlapping tokens.
+    static func deduplicateAndSort(_ tokens: [HighlightToken]) -> [HighlightToken] {
+        let sorted = tokens.sorted { $0.range.lowerBound < $1.range.lowerBound }
+        var result: [HighlightToken] = []
+        var lastEnd: String.Index?
+
+        for token in sorted {
+            if let end = lastEnd, token.range.lowerBound < end {
+                continue
+            }
+            result.append(token)
+            lastEnd = token.range.upperBound
+        }
+
+        return result
+    }
+
+    /// Renders highlight tokens to HTML with span elements.
+    static func renderTokensToHTML(code: String, tokens: [HighlightToken]) -> String {
+        var result = ""
+        var currentIndex = code.startIndex
+
+        for token in tokens {
+            if currentIndex < token.range.lowerBound {
+                result += String(code[currentIndex..<token.range.lowerBound]).htmlEscaped
+            }
+
+            let tokenText = String(code[token.range])
+            if token.tokenType != .plain {
+                result += "<span class=\"token-\(token.tokenType.rawValue)\">"
+                result += tokenText.htmlEscaped
+                result += "</span>"
+            } else {
+                result += tokenText.htmlEscaped
+            }
+
+            currentIndex = token.range.upperBound
+        }
+
+        if currentIndex < code.endIndex {
+            result += String(code[currentIndex...]).htmlEscaped
+        }
+
+        return result
+    }
+}


### PR DESCRIPTION
## Summary
- Create `TreeSitterTokenProcessor` utility enum with shared tree-sitter processing methods
- Update `TreeSitterHighlighter` to use the shared utility
- Update `LazyTreeSitterHighlighter` to use the shared utility
- Eliminates ~100 lines of duplicate code

## Methods Extracted
- `extractTokens(from:code:query:)` - Extract highlight tokens from parsed tree
- `byteRangeToStringRange(_:in:)` - Convert tree-sitter byte ranges to String.Index ranges
- `mapCaptureToTokenType(_:)` - Map capture names to token types
- `deduplicateAndSort(_:)` - Sort tokens and remove overlaps
- `renderTokensToHTML(code:tokens:)` - Render tokens to HTML with spans

## Verification
- All existing tests pass (functionality unchanged)
- Swiftlint passes
- Net reduction of ~110 lines

Closes #24