### PR TITLE
docs: document Swift special-casing rationale in LazyTreeSitterHighlighter

### DIFF
--- a/SwiftMarkdownCore/SyntaxHighlighting/LazyTreeSitterHighlighter.swift
+++ b/SwiftMarkdownCore/SyntaxHighlighting/LazyTreeSitterHighlighter.swift
@@ -8,6 +8,21 @@ import TreeSitterSwift
 /// grammars from GitHub releases. Swift is always available (bundled),
 /// while other languages are downloaded on first use.
 ///
+/// ## Swift Special-Casing
+///
+/// Swift receives special handling throughout this class because it's the only
+/// bundled grammar that works offline without downloads. This enables:
+///
+/// - **Synchronous API** (`highlight`, `highlightToHTML`) - Only supports Swift
+///   because other grammars require async network operations
+/// - **Immediate availability** - Swift highlighting works on first use without
+///   waiting for downloads
+/// - **Offline support** - Swift always works, even without network access
+///
+/// This intentional design means Swift checks appear in multiple methods. While
+/// this could be abstracted with a "bundled grammar" concept, the explicit checks
+/// are clearer about the behavior and avoid over-engineering for a single grammar.
+///
 /// ## Example
 /// ```swift
 /// let highlighter = LazyTreeSitterHighlighter()


### PR DESCRIPTION
## Summary

Document the design decision behind Swift special-casing in `LazyTreeSitterHighlighter` rather than refactoring to remove it.

## Rationale

After analyzing the code, the Swift special-casing is intentional and provides real benefits:

| Benefit | Description |
|---------|-------------|
| **Synchronous API** | Only Swift supports `highlight()` and `highlightToHTML()` because other grammars require async network operations |
| **Immediate availability** | Swift highlighting works on first use without waiting for downloads |
| **Offline support** | Swift always works, even without network access |

Abstracting this into a "bundled grammar" concept would:
- Add complexity for a single grammar
- Require checking "is bundled" in multiple places anyway
- Make the code less obvious about its behavior

The explicit Swift checks are clearer about the design.

## Changes
- Added class-level documentation explaining why Swift is special-cased
- Documented the benefits of this approach

Closes #27