### PR TITLE
refactor: simplify HTMLElementRenderer and use _ for unused parameters

### DIFF
--- a/SwiftMarkdownCore/Rendering/AsyncHTMLWalker.swift
+++ b/SwiftMarkdownCore/Rendering/AsyncHTMLWalker.swift
@@ -206,7 +206,7 @@ struct AsyncHTMLWalker {
         result += HTMLElementRenderer.closeTagWithNewline("blockquote")
     }
 
-    private mutating func visitThematicBreak(_ thematicBreak: ThematicBreak) {
+    private mutating func visitThematicBreak(_: ThematicBreak) {
         result += HTMLElementRenderer.renderThematicBreak()
     }
 
@@ -235,11 +235,11 @@ struct AsyncHTMLWalker {
         result += HTMLElementRenderer.closeTable()
     }
 
-    private mutating func visitLineBreak(_ lineBreak: LineBreak) {
+    private mutating func visitLineBreak(_: LineBreak) {
         result += HTMLElementRenderer.renderLineBreak()
     }
 
-    private mutating func visitSoftBreak(_ softBreak: SoftBreak) {
+    private mutating func visitSoftBreak(_: SoftBreak) {
         result += HTMLElementRenderer.renderSoftBreak()
     }
 

--- a/SwiftMarkdownCore/Rendering/HTMLRenderer.swift
+++ b/SwiftMarkdownCore/Rendering/HTMLRenderer.swift
@@ -235,7 +235,7 @@ struct HTMLWalker: MarkupWalker {
         result += HTMLElementRenderer.closeTagWithNewline("blockquote")
     }
 
-    mutating func visitThematicBreak(_ thematicBreak: ThematicBreak) {
+    mutating func visitThematicBreak(_: ThematicBreak) {
         result += HTMLElementRenderer.renderThematicBreak()
     }
 
@@ -264,11 +264,11 @@ struct HTMLWalker: MarkupWalker {
         result += HTMLElementRenderer.closeTable()
     }
 
-    mutating func visitLineBreak(_ lineBreak: LineBreak) {
+    mutating func visitLineBreak(_: LineBreak) {
         result += HTMLElementRenderer.renderLineBreak()
     }
 
-    mutating func visitSoftBreak(_ softBreak: SoftBreak) {
+    mutating func visitSoftBreak(_: SoftBreak) {
         result += HTMLElementRenderer.renderSoftBreak()
     }
 


### PR DESCRIPTION
## Summary

Minor code clarity improvements in rendering code with no behavioral changes.

## Changes

### HTMLElementRenderer.swift
- `renderImage`: Reduce mutable state with early return pattern
- `openCodeBlock`: Use ternary expression instead of if/else
- `openListItem`: Use guard for early return

### AsyncHTMLWalker.swift & HTMLRenderer.swift
- Mark unused parameters with `_` in visit methods:
  - `visitThematicBreak`
  - `visitLineBreak`
  - `visitSoftBreak`

## Test plan

- [x] All 160 existing tests pass
- [x] Build succeeds
- [x] SwiftLint passes with no violations

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)