### PR TITLE
feat: show grammar sources in Languages settings UI

### DIFF
--- a/SwiftMarkdown/Settings/LanguagesSettingsView.swift
+++ b/SwiftMarkdown/Settings/LanguagesSettingsView.swift
@@ -90,7 +90,7 @@ struct LanguagesSettingsView: View {
                         .foregroundColor(.secondary)
                     Text(LanguagesViewModel.formatBytes(viewModel.cacheSize))
                         .font(.caption)
-                    Text("(\(viewModel.grammars.filter { $0.isInstalled && !$0.isBundled }.count) languages)")
+                    Text("(\(viewModel.grammars.filter { $0.source == .cached }.count) downloaded)")
                         .font(.caption)
                         .foregroundColor(.secondary)
                 }
@@ -125,8 +125,12 @@ struct GrammarRowView: View {
                 HStack {
                     Text(grammar.displayName)
                         .fontWeight(.medium)
-                    if grammar.isBundled {
-                        Text("(bundled)")
+                    if grammar.source == .homebrew {
+                        Text("(via Homebrew)")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    } else if grammar.source == .cached {
+                        Text("(downloaded)")
                             .font(.caption)
                             .foregroundColor(.secondary)
                     }


### PR DESCRIPTION
## Summary

Update the Languages settings UI to display grammar sources and support the multi-source discovery model.

## Changes

### LanguagesViewModel.swift
- Replace `isInstalled: Bool` with `source: GrammarSource` to track grammar origin
- Remove hardcoded Swift `GrammarItem` - all grammars now discovered dynamically
- Use `grammarManager.grammarSource(_:)` to determine source for each grammar
- `isInstalled` is now a computed property based on `source != .notInstalled`

### LanguagesSettingsView.swift
- Display source badges:
  - "(via Homebrew)" for `source == .homebrew`
  - "(downloaded)" for `source == .cached`
- Update footer to show count of downloaded grammars

## Expected Behavior

| Grammar Source | Badge | Action |
|---------------|-------|--------|
| `.homebrew` | "(via Homebrew)" | Shows "Installed" |
| `.cached` | "(downloaded)" | Shows "Installed" |
| `.notInstalled` | None | Shows "Download" button |

## Test plan

- [x] All 160 existing tests pass
- [x] Build succeeds
- [x] SwiftLint passes with no violations

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)