### PR TITLE
fix: restore executable permissions in release DMG

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,6 +111,15 @@ jobs:
           name: app-bundle
           path: build/${{ env.APP_NAME }}.app
 
+      - name: Restore executable permissions
+        run: |
+          # GitHub Actions artifacts lose execute permissions
+          chmod +x "build/${{ env.APP_NAME }}.app/Contents/MacOS/${{ env.APP_NAME }}"
+          # Also fix Quick Look extension if present
+          if [ -f "build/${{ env.APP_NAME }}.app/Contents/PlugIns/SwiftMarkdownQuickLook.appex/Contents/MacOS/SwiftMarkdownQuickLook" ]; then
+            chmod +x "build/${{ env.APP_NAME }}.app/Contents/PlugIns/SwiftMarkdownQuickLook.appex/Contents/MacOS/SwiftMarkdownQuickLook"
+          fi
+
       - name: Create DMG
         id: dmg
         run: |


### PR DESCRIPTION
## Summary

- Add step to restore execute permissions after downloading app artifact
- Fixes app failing to launch with "can't be opened" error

## Root Cause

GitHub Actions `upload-artifact`/`download-artifact` strips execute permissions from files.

## Changes

Added "Restore executable permissions" step in the `package` job that runs `chmod +x` on:
- Main app binary
- Quick Look extension (if present)

## Test Plan

- [ ] Verify next release DMG installs and launches correctly

Closes #57

🤖 Generated with [Claude Code](https://claude.ai/code)