### PR TITLE
feat: add content-based markdown file validation

### DIFF
--- a/SwiftMarkdown/DocumentViewModel.swift
+++ b/SwiftMarkdown/DocumentViewModel.swift
@@ -22,8 +22,10 @@ final class DocumentViewModel: ObservableObject {
 
     /// Load and render a markdown file.
     func loadFile(at url: URL) async {
-        guard DocumentViewModel.isMarkdownFile(url) else {
-            errorMessage = "Not a markdown file: \(url.lastPathComponent)"
+        // Validate file extension and content
+        let validationResult = MarkdownFileValidator.validate(url)
+        guard validationResult.isValid else {
+            errorMessage = validationResult.errorMessage ?? "Invalid file"
             return
         }
 

--- a/SwiftMarkdownCore/Utilities/MarkdownFileValidator.swift
+++ b/SwiftMarkdownCore/Utilities/MarkdownFileValidator.swift
@@ -1,13 +1,154 @@
 import Foundation
 
+/// Result of validating a file as markdown.
+public enum MarkdownValidationResult: Equatable, Sendable {
+    /// File appears to be valid markdown (text content with markdown extension).
+    case valid
+    /// File has a markdown extension but contains binary data.
+    case binaryContent(detectedType: String?)
+    /// File does not have a markdown extension.
+    case invalidExtension
+    /// File could not be read.
+    case unreadable(error: String)
+
+    /// Returns true if the validation result indicates a valid markdown file.
+    public var isValid: Bool {
+        if case .valid = self { return true }
+        return false
+    }
+
+    /// Returns a user-friendly error message, or nil if valid.
+    public var errorMessage: String? {
+        switch self {
+        case .valid:
+            return nil
+        case .binaryContent(let detectedType):
+            if let type = detectedType {
+                return "This appears to be a \(type) file, not markdown"
+            }
+            return "This file contains binary data, not text"
+        case .invalidExtension:
+            return "Not a markdown file"
+        case .unreadable(let error):
+            return "Could not read file: \(error)"
+        }
+    }
+}
+
 /// Utilities for validating markdown files.
 public enum MarkdownFileValidator {
     /// Supported file extensions for markdown files.
     public static let supportedExtensions: Set<String> = ["md", "markdown", "mdown", "mkdn", "mkd"]
 
-    /// Check if a URL points to a valid markdown file based on extension.
+    /// Number of bytes to read for content validation.
+    /// 8KB is enough to detect binary content and magic bytes.
+    private static let sampleSize = 8192
+
+    /// Magic byte signatures for common binary formats.
+    private static let magicBytes: [(signature: [UInt8], name: String)] = [
+        ([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A], "PNG image"),
+        ([0xFF, 0xD8, 0xFF], "JPEG image"),
+        ([0x47, 0x49, 0x46, 0x38], "GIF image"),
+        ([0x25, 0x50, 0x44, 0x46], "PDF document"),
+        ([0x50, 0x4B, 0x03, 0x04], "ZIP archive"),
+        ([0xCF, 0xFA, 0xED, 0xFE], "Mach-O binary"),
+        ([0xFE, 0xED, 0xFA, 0xCF], "Mach-O binary"),
+        ([0xFE, 0xED, 0xFA, 0xCE], "Mach-O binary"),
+        ([0xCE, 0xFA, 0xED, 0xFE], "Mach-O binary"),
+        ([0x7F, 0x45, 0x4C, 0x46], "ELF binary"),
+        ([0x52, 0x49, 0x46, 0x46], "RIFF container"),  // WebP, WAV, AVI
+        ([0x00, 0x00, 0x00, 0x0C, 0x6A, 0x50], "JPEG 2000 image"),
+        ([0x49, 0x44, 0x33], "MP3 audio"),  // ID3 tag
+        ([0xFF, 0xFB], "MP3 audio"),
+        ([0xFF, 0xFA], "MP3 audio"),
+        ([0x4F, 0x67, 0x67, 0x53], "OGG container"),
+        ([0x66, 0x4C, 0x61, 0x43], "FLAC audio"),
+        ([0x1A, 0x45, 0xDF, 0xA3], "WebM/MKV video"),
+        ([0x00, 0x00, 0x00], "possibly MP4/MOV")  // Needs more context but catches most
+    ]
+
+    /// Check if a URL points to a valid markdown file based on extension only.
+    /// For content-aware validation, use `validate(_:)` instead.
     public static func isMarkdownFile(_ url: URL) -> Bool {
         let ext = url.pathExtension.lowercased()
         return supportedExtensions.contains(ext)
+    }
+
+    /// Validates a file as markdown by checking both extension and content.
+    ///
+    /// This method:
+    /// 1. Checks the file extension is a valid markdown extension
+    /// 2. Reads the first 8KB of the file
+    /// 3. Checks for binary content (null bytes, invalid UTF-8, or known binary magic bytes)
+    ///
+    /// - Parameter url: The file URL to validate.
+    /// - Returns: A validation result indicating whether the file is valid markdown.
+    public static func validate(_ url: URL) -> MarkdownValidationResult {
+        // First check extension
+        guard isMarkdownFile(url) else {
+            return .invalidExtension
+        }
+
+        // Read sample of file content
+        let data: Data
+        do {
+            let handle = try FileHandle(forReadingFrom: url)
+            defer { try? handle.close() }
+            data = handle.readData(ofLength: sampleSize)
+        } catch {
+            return .unreadable(error: error.localizedDescription)
+        }
+
+        // Empty files are valid (edge case but allowed)
+        if data.isEmpty {
+            return .valid
+        }
+
+        // Check for known binary formats by magic bytes
+        if let binaryType = detectBinaryType(data) {
+            return .binaryContent(detectedType: binaryType)
+        }
+
+        // Check if content is valid UTF-8 text
+        if !isTextContent(data) {
+            return .binaryContent(detectedType: nil)
+        }
+
+        return .valid
+    }
+
+    /// Checks if data appears to be valid UTF-8 text content.
+    ///
+    /// Detects binary content by:
+    /// - Checking for null bytes (common in binary formats)
+    /// - Verifying the data can be decoded as valid UTF-8
+    ///
+    /// - Parameter data: The data to check.
+    /// - Returns: `true` if the data appears to be text, `false` if binary.
+    public static func isTextContent(_ data: Data) -> Bool {
+        // Check for null bytes (strong indicator of binary)
+        if data.contains(0x00) {
+            return false
+        }
+
+        // Try to decode as UTF-8
+        return String(data: data, encoding: .utf8) != nil
+    }
+
+    /// Attempts to identify a binary file type from its magic bytes.
+    ///
+    /// - Parameter data: The file data to check.
+    /// - Returns: The detected file type name, or `nil` if no known type matched.
+    public static func detectBinaryType(_ data: Data) -> String? {
+        let bytes = [UInt8](data)
+
+        for (signature, name) in magicBytes where bytes.count >= signature.count {
+            let prefix = Array(bytes.prefix(signature.count))
+            if prefix == signature {
+                return name
+            }
+        }
+
+        return nil
     }
 }

--- a/SwiftMarkdownTests/MarkdownFileValidatorTests.swift
+++ b/SwiftMarkdownTests/MarkdownFileValidatorTests.swift
@@ -2,7 +2,30 @@ import XCTest
 @testable import SwiftMarkdownCore
 
 final class MarkdownFileValidatorTests: XCTestCase {
-    // MARK: - isMarkdownFile Tests
+    // MARK: - Test File Setup
+
+    // swiftlint:disable:next implicitly_unwrapped_optional
+    private var tempDirectory: URL!
+
+    override func setUp() {
+        super.setUp()
+        tempDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try? FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tempDirectory)
+        super.tearDown()
+    }
+
+    private func createTempFile(name: String, contents: Data) -> URL {
+        let url = tempDirectory.appendingPathComponent(name)
+        try? contents.write(to: url)
+        return url
+    }
+
+    // MARK: - isMarkdownFile Tests (Extension-Only)
 
     func testIsMarkdownFileWithMdExtension() {
         let url = URL(fileURLWithPath: "/path/to/file.md")
@@ -66,5 +89,249 @@ final class MarkdownFileValidatorTests: XCTestCase {
     func testSupportedExtensionsContainsExpectedValues() {
         let expected: Set<String> = ["md", "markdown", "mdown", "mkdn", "mkd"]
         XCTAssertEqual(MarkdownFileValidator.supportedExtensions, expected)
+    }
+
+    // MARK: - validate Tests (Content-Aware)
+
+    func testValidateReturnsValidForTextMarkdown() {
+        let content = "# Hello World\n\nThis is **markdown**."
+        let url = createTempFile(name: "test.md", contents: Data(content.utf8))
+
+        let result = MarkdownFileValidator.validate(url)
+        XCTAssertEqual(result, .valid)
+        XCTAssertTrue(result.isValid)
+        XCTAssertNil(result.errorMessage)
+    }
+
+    func testValidateReturnsValidForEmptyFile() {
+        let url = createTempFile(name: "empty.md", contents: Data())
+
+        let result = MarkdownFileValidator.validate(url)
+        XCTAssertEqual(result, .valid)
+    }
+
+    func testValidateReturnsInvalidExtensionForWrongExtension() {
+        let content = "# Hello World"
+        let url = createTempFile(name: "test.txt", contents: Data(content.utf8))
+
+        let result = MarkdownFileValidator.validate(url)
+        XCTAssertEqual(result, .invalidExtension)
+        XCTAssertFalse(result.isValid)
+        XCTAssertEqual(result.errorMessage, "Not a markdown file")
+    }
+
+    func testValidateDetectsPNG() {
+        // PNG magic bytes: 89 50 4E 47 0D 0A 1A 0A
+        let pngData = Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00])
+        let url = createTempFile(name: "fake.md", contents: pngData)
+
+        let result = MarkdownFileValidator.validate(url)
+        XCTAssertEqual(result, .binaryContent(detectedType: "PNG image"))
+        XCTAssertFalse(result.isValid)
+        XCTAssertEqual(result.errorMessage, "This appears to be a PNG image file, not markdown")
+    }
+
+    func testValidateDetectsJPEG() {
+        // JPEG magic bytes: FF D8 FF
+        let jpegData = Data([0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10])
+        let url = createTempFile(name: "fake.md", contents: jpegData)
+
+        let result = MarkdownFileValidator.validate(url)
+        XCTAssertEqual(result, .binaryContent(detectedType: "JPEG image"))
+        XCTAssertFalse(result.isValid)
+        XCTAssertEqual(result.errorMessage, "This appears to be a JPEG image file, not markdown")
+    }
+
+    func testValidateDetectsGIF() {
+        // GIF magic bytes: 47 49 46 38 (GIF8)
+        let gifData = Data([0x47, 0x49, 0x46, 0x38, 0x39, 0x61])
+        let url = createTempFile(name: "fake.md", contents: gifData)
+
+        let result = MarkdownFileValidator.validate(url)
+        XCTAssertEqual(result, .binaryContent(detectedType: "GIF image"))
+        XCTAssertFalse(result.isValid)
+    }
+
+    func testValidateDetectsPDF() {
+        // PDF magic bytes: 25 50 44 46 (%PDF)
+        let pdfData = Data([0x25, 0x50, 0x44, 0x46, 0x2D, 0x31, 0x2E])
+        let url = createTempFile(name: "fake.md", contents: pdfData)
+
+        let result = MarkdownFileValidator.validate(url)
+        XCTAssertEqual(result, .binaryContent(detectedType: "PDF document"))
+        XCTAssertFalse(result.isValid)
+        XCTAssertEqual(result.errorMessage, "This appears to be a PDF document file, not markdown")
+    }
+
+    func testValidateDetectsZIP() {
+        // ZIP magic bytes: 50 4B 03 04
+        let zipData = Data([0x50, 0x4B, 0x03, 0x04, 0x14, 0x00])
+        let url = createTempFile(name: "fake.md", contents: zipData)
+
+        let result = MarkdownFileValidator.validate(url)
+        XCTAssertEqual(result, .binaryContent(detectedType: "ZIP archive"))
+        XCTAssertFalse(result.isValid)
+    }
+
+    func testValidateDetectsMachO() {
+        // Mach-O magic bytes: CF FA ED FE (64-bit little-endian)
+        let machoData = Data([0xCF, 0xFA, 0xED, 0xFE, 0x07, 0x00])
+        let url = createTempFile(name: "fake.md", contents: machoData)
+
+        let result = MarkdownFileValidator.validate(url)
+        XCTAssertEqual(result, .binaryContent(detectedType: "Mach-O binary"))
+        XCTAssertFalse(result.isValid)
+    }
+
+    func testValidateDetectsELF() {
+        // ELF magic bytes: 7F 45 4C 46
+        let elfData = Data([0x7F, 0x45, 0x4C, 0x46, 0x02, 0x01])
+        let url = createTempFile(name: "fake.md", contents: elfData)
+
+        let result = MarkdownFileValidator.validate(url)
+        XCTAssertEqual(result, .binaryContent(detectedType: "ELF binary"))
+        XCTAssertFalse(result.isValid)
+    }
+
+    func testValidateDetectsBinaryWithNullBytes() {
+        // Generic binary data with null bytes (not matching any magic bytes)
+        let binaryData = Data([0x01, 0x02, 0x00, 0x03, 0x04, 0x00])
+        let url = createTempFile(name: "fake.md", contents: binaryData)
+
+        let result = MarkdownFileValidator.validate(url)
+        XCTAssertEqual(result, .binaryContent(detectedType: nil))
+        XCTAssertFalse(result.isValid)
+        XCTAssertEqual(result.errorMessage, "This file contains binary data, not text")
+    }
+
+    func testValidateReturnsUnreadableForNonexistentFile() {
+        let url = tempDirectory.appendingPathComponent("nonexistent.md")
+
+        let result = MarkdownFileValidator.validate(url)
+        if case .unreadable(let error) = result {
+            XCTAssertFalse(error.isEmpty)
+        } else {
+            XCTFail("Expected unreadable result")
+        }
+        XCTAssertFalse(result.isValid)
+    }
+
+    func testValidateHandlesUTF8WithSpecialCharacters() {
+        let content = "# Hello 世界\n\n日本語テキスト with emoji 🎉"
+        let url = createTempFile(name: "unicode.md", contents: Data(content.utf8))
+
+        let result = MarkdownFileValidator.validate(url)
+        XCTAssertEqual(result, .valid)
+    }
+
+    func testValidateHandlesUTF8BOM() {
+        // UTF-8 BOM: EF BB BF followed by text
+        var data = Data([0xEF, 0xBB, 0xBF])
+        data.append(Data("# Hello World".utf8))
+        let url = createTempFile(name: "bom.md", contents: data)
+
+        let result = MarkdownFileValidator.validate(url)
+        XCTAssertEqual(result, .valid)
+    }
+
+    // MARK: - isTextContent Tests
+
+    func testIsTextContentReturnsTrueForPlainText() {
+        let data = Data("Hello, World!".utf8)
+        XCTAssertTrue(MarkdownFileValidator.isTextContent(data))
+    }
+
+    func testIsTextContentReturnsTrueForUTF8() {
+        let data = Data("日本語".utf8)
+        XCTAssertTrue(MarkdownFileValidator.isTextContent(data))
+    }
+
+    func testIsTextContentReturnsFalseForNullBytes() {
+        let data = Data([0x48, 0x65, 0x6C, 0x6C, 0x6F, 0x00, 0x57])
+        XCTAssertFalse(MarkdownFileValidator.isTextContent(data))
+    }
+
+    func testIsTextContentReturnsFalseForInvalidUTF8() {
+        // Invalid UTF-8 sequence
+        let data = Data([0xFF, 0xFE, 0x00, 0x01])
+        XCTAssertFalse(MarkdownFileValidator.isTextContent(data))
+    }
+
+    func testIsTextContentReturnsTrueForEmptyData() {
+        // Empty data is valid UTF-8
+        let data = Data()
+        XCTAssertTrue(MarkdownFileValidator.isTextContent(data))
+    }
+
+    // MARK: - detectBinaryType Tests
+
+    func testDetectBinaryTypeReturnsPNGForPNGData() {
+        let data = Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
+        XCTAssertEqual(MarkdownFileValidator.detectBinaryType(data), "PNG image")
+    }
+
+    func testDetectBinaryTypeReturnsJPEGForJPEGData() {
+        let data = Data([0xFF, 0xD8, 0xFF, 0xE0])
+        XCTAssertEqual(MarkdownFileValidator.detectBinaryType(data), "JPEG image")
+    }
+
+    func testDetectBinaryTypeReturnsNilForTextData() {
+        let data = Data("# Hello World".utf8)
+        XCTAssertNil(MarkdownFileValidator.detectBinaryType(data))
+    }
+
+    func testDetectBinaryTypeReturnsNilForEmptyData() {
+        let data = Data()
+        XCTAssertNil(MarkdownFileValidator.detectBinaryType(data))
+    }
+
+    func testDetectBinaryTypeReturnsNilForPartialSignature() {
+        // Only first 2 bytes of PNG signature
+        let data = Data([0x89, 0x50])
+        XCTAssertNil(MarkdownFileValidator.detectBinaryType(data))
+    }
+
+    // MARK: - MarkdownValidationResult Tests
+
+    func testValidationResultIsValidReturnsCorrectValues() {
+        XCTAssertTrue(MarkdownValidationResult.valid.isValid)
+        XCTAssertFalse(MarkdownValidationResult.invalidExtension.isValid)
+        XCTAssertFalse(MarkdownValidationResult.binaryContent(detectedType: "PNG").isValid)
+        XCTAssertFalse(MarkdownValidationResult.binaryContent(detectedType: nil).isValid)
+        XCTAssertFalse(MarkdownValidationResult.unreadable(error: "test").isValid)
+    }
+
+    func testValidationResultErrorMessageReturnsCorrectValues() {
+        XCTAssertNil(MarkdownValidationResult.valid.errorMessage)
+        XCTAssertEqual(MarkdownValidationResult.invalidExtension.errorMessage, "Not a markdown file")
+        XCTAssertEqual(
+            MarkdownValidationResult.binaryContent(detectedType: "PNG image").errorMessage,
+            "This appears to be a PNG image file, not markdown"
+        )
+        XCTAssertEqual(
+            MarkdownValidationResult.binaryContent(detectedType: nil).errorMessage,
+            "This file contains binary data, not text"
+        )
+        XCTAssertEqual(
+            MarkdownValidationResult.unreadable(error: "test error").errorMessage,
+            "Could not read file: test error"
+        )
+    }
+
+    func testValidationResultEquality() {
+        XCTAssertEqual(MarkdownValidationResult.valid, MarkdownValidationResult.valid)
+        XCTAssertEqual(MarkdownValidationResult.invalidExtension, MarkdownValidationResult.invalidExtension)
+        XCTAssertEqual(
+            MarkdownValidationResult.binaryContent(detectedType: "PNG"),
+            MarkdownValidationResult.binaryContent(detectedType: "PNG")
+        )
+        XCTAssertNotEqual(
+            MarkdownValidationResult.binaryContent(detectedType: "PNG"),
+            MarkdownValidationResult.binaryContent(detectedType: "JPEG")
+        )
+        XCTAssertNotEqual(
+            MarkdownValidationResult.valid,
+            MarkdownValidationResult.invalidExtension
+        )
     }
 }


### PR DESCRIPTION
## Summary

- Add `MarkdownValidationResult` enum with `valid`, `binaryContent`, `invalidExtension`, and `unreadable` cases
- Add `validate(_:)` method that checks file content in addition to extension
- Detect binary files by magic bytes (PNG, JPEG, GIF, PDF, ZIP, Mach-O, ELF, etc.) and null bytes
- Update `DocumentViewModel` to use content-aware validation with specific error messages
- Add 27 new tests for content validation covering all binary format detection

## Test plan

- [x] All 199 tests pass
- [x] SwiftLint passes with no violations
- [x] Manually test: drag a renamed PNG (e.g., `image.md`) onto the app - should show "This appears to be a PNG image file, not markdown"
- [x] Manually test: drag a valid markdown file - should render normally
- [ ] Manually test: use File > Open with a binary file renamed to .md - should show appropriate error

Closes #65