### PR TITLE
fix: improve document rendering with proper light/dark theme support

### DIFF
--- a/SwiftMarkdownCore/Resources/highlight.css
+++ b/SwiftMarkdownCore/Resources/highlight.css
@@ -1,4 +1,5 @@
 /* SwiftMarkdown Document Styles */
+/* Colors derived from GitHub's markdown styling */
 
 /* ============================================
    Document Base Styling
@@ -12,7 +13,7 @@ body {
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
     font-size: 16px;
     line-height: 1.6;
-    color: #24292f;
+    color: #1f2328;
     background-color: #ffffff;
     padding: 24px 32px;
     max-width: 900px;
@@ -22,8 +23,8 @@ body {
 
 @media (prefers-color-scheme: dark) {
     body {
-        color: #e6edf3;
-        background-color: #0d1117;
+        color: #d1d7e0;
+        background-color: #212830;
     }
 }
 
@@ -41,23 +42,23 @@ h1, h2, h3, h4, h5, h6 {
 h1 {
     font-size: 2em;
     padding-bottom: 0.3em;
-    border-bottom: 1px solid #d0d7de;
+    border-bottom: 1px solid #d1d9e0;
 }
 
 h2 {
     font-size: 1.5em;
     padding-bottom: 0.3em;
-    border-bottom: 1px solid #d0d7de;
+    border-bottom: 1px solid #d1d9e0;
 }
 
 h3 { font-size: 1.25em; }
 h4 { font-size: 1em; }
 h5 { font-size: 0.875em; }
-h6 { font-size: 0.85em; color: #656d76; }
+h6 { font-size: 0.85em; color: #59636e; }
 
 @media (prefers-color-scheme: dark) {
     h1, h2 { border-bottom-color: #3d444d; }
-    h6 { color: #8b949e; }
+    h6 { color: #9198a1; }
 }
 
 p {
@@ -79,7 +80,7 @@ a:hover {
 }
 
 @media (prefers-color-scheme: dark) {
-    a { color: #58a6ff; }
+    a { color: #478be6; }
 }
 
 /* ============================================
@@ -122,8 +123,8 @@ input[type="checkbox"] {
 
 blockquote {
     padding: 0 1em;
-    color: #656d76;
-    border-left: 4px solid #d0d7de;
+    color: #59636e;
+    border-left: 4px solid #d1d9e0;
     margin: 0 0 16px 0;
 }
 
@@ -137,7 +138,7 @@ blockquote > :last-child {
 
 @media (prefers-color-scheme: dark) {
     blockquote {
-        color: #8b949e;
+        color: #9198a1;
         border-left-color: #3d444d;
     }
 }
@@ -160,7 +161,7 @@ pre {
 
 @media (prefers-color-scheme: dark) {
     pre {
-        background-color: #161b22;
+        background-color: #262c36;
     }
 }
 
@@ -178,7 +179,7 @@ code:not(pre code) {
 
 @media (prefers-color-scheme: dark) {
     code:not(pre code) {
-        background-color: rgba(110, 118, 129, 0.4);
+        background-color: rgba(101, 108, 118, 0.4);
     }
 }
 
@@ -197,7 +198,7 @@ table {
 
 th, td {
     padding: 6px 13px;
-    border: 1px solid #d0d7de;
+    border: 1px solid #d1d9e0;
 }
 
 th {
@@ -215,10 +216,10 @@ tr:nth-child(even) {
         border-color: #3d444d;
     }
     th {
-        background-color: #161b22;
+        background-color: #262c36;
     }
     tr:nth-child(even) {
-        background-color: #161b22;
+        background-color: #262c36;
     }
 }
 
@@ -229,7 +230,7 @@ tr:nth-child(even) {
 hr {
     border: 0;
     height: 1px;
-    background-color: #d0d7de;
+    background-color: #d1d9e0;
     margin: 24px 0;
 }
 

--- a/SwiftMarkdownCore/Themes/SyntaxTheme.swift
+++ b/SwiftMarkdownCore/Themes/SyntaxTheme.swift
@@ -100,24 +100,24 @@ public struct SyntaxTheme: Equatable, Sendable {
     /// The default theme with VS Code-inspired light and dark colors.
     public static let `default` = SyntaxTheme(light: .light, dark: .dark)
 
-    /// Base document styling CSS for light/dark mode support.
+    /// Base document styling CSS for light/dark mode support (GitHub colors).
     private static let documentCSS = """
         html { color-scheme: light dark; }
         body {
             font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
-            font-size: 16px; line-height: 1.6; color: #24292f; background-color: #ffffff;
+            font-size: 16px; line-height: 1.6; color: #1f2328; background-color: #ffffff;
             padding: 24px 32px; max-width: 900px; margin: 0 auto;
         }
-        @media (prefers-color-scheme: dark) { body { color: #e6edf3; background-color: #0d1117; } }
+        @media (prefers-color-scheme: dark) { body { color: #d1d7e0; background-color: #212830; } }
         h1, h2, h3, h4, h5, h6 { margin-top: 24px; margin-bottom: 16px; font-weight: 600; }
         a { color: #0969da; text-decoration: none; }
         a:hover { text-decoration: underline; }
-        @media (prefers-color-scheme: dark) { a { color: #58a6ff; } }
+        @media (prefers-color-scheme: dark) { a { color: #478be6; } }
         pre {
             background-color: #f6f8fa; border-radius: 6px; padding: 16px; overflow-x: auto;
             font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; font-size: 14px;
         }
-        @media (prefers-color-scheme: dark) { pre { background-color: #161b22; } }
+        @media (prefers-color-scheme: dark) { pre { background-color: #262c36; } }
         code { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; }
         """
 


### PR DESCRIPTION
## Summary

- Add comprehensive document styling to `highlight.css` including body, headings, links, lists, blockquotes, tables, inline code, horizontal rules, and images
- Use GitHub-inspired color palette with proper light/dark mode support via `@media (prefers-color-scheme: dark)` media queries
- Use system fonts (`-apple-system`) for native macOS appearance
- Update `SyntaxTheme.generateCSS()` fallback to include document styling

## Before

The rendered markdown appeared dark and hard to read because:
1. `MarkdownWebView` sets `drawsBackground = false`, making the WebView transparent
2. `highlight.css` only styled code blocks and syntax tokens - no body/document styling
3. No text color, background color, or typography defined for the document body

## After

- Light mode: Light background (#ffffff), dark text (#24292f)
- Dark mode: Dark background (#0d1117), light text (#e6edf3)
- Code blocks have subtle background differentiation
- All markdown elements properly styled (headings, links, lists, blockquotes, tables, etc.)
- Appearance matches native macOS aesthetics

## Test plan

- [x] All tests pass
- [x] SwiftLint passes with no violations
- [ ] Open a markdown file with various elements (headings, code, links, tables, blockquotes)
- [ ] Toggle system appearance between Light and Dark mode
- [ ] Verify all elements are readable and properly styled in both modes

Closes #63