### PR TITLE
perf: share grammar cache across document loads

### DIFF
--- a/SwiftMarkdown/DocumentViewModel.swift
+++ b/SwiftMarkdown/DocumentViewModel.swift
@@ -51,9 +51,8 @@ final class DocumentViewModel: ObservableObject {
     /// Render markdown content to HTML with syntax highlighting.
     private func renderMarkdown(_ content: String) async -> String {
         let document = MarkdownParser.parseDocument(content)
-        let highlighter = LazyTreeSitterHighlighter()
         let renderer = HTMLRenderer(wrapInDocument: true)
-        return await renderer.renderAsync(document, highlighter: highlighter)
+        return await renderer.renderAsync(document, highlighter: LazyTreeSitterHighlighter.shared)
     }
 
     /// Clear the current document.

--- a/SwiftMarkdownCore/SyntaxHighlighting/LazyTreeSitterHighlighter.swift
+++ b/SwiftMarkdownCore/SyntaxHighlighting/LazyTreeSitterHighlighter.swift
@@ -26,6 +26,9 @@ import SwiftTreeSitter
 /// let html = highlighter.highlightToHTML(code: code, language: "python")  // Returns escaped code if not installed
 /// ```
 public final class LazyTreeSitterHighlighter: HTMLSyntaxHighlighter, @unchecked Sendable {
+    /// Shared highlighter instance for caching grammar configurations across renders.
+    public static let shared = LazyTreeSitterHighlighter()
+
     private let parser: Parser
     private let grammarManager: GrammarManager
     private var languageConfigs: [String: LanguageConfiguration] = [:]


### PR DESCRIPTION
## Summary
- Adds a shared `LazyTreeSitterHighlighter.shared` instance
- Uses the shared instance in `DocumentViewModel` to preserve grammar configurations across renders

## Why
Previously, each document load created a new `LazyTreeSitterHighlighter()`, discarding the grammar configuration cache. Now the cache persists across loads.

## Changes
- `LazyTreeSitterHighlighter.swift`: Add `static let shared`
- `DocumentViewModel.swift`: Use `.shared` instead of creating new instance

## Thread Safety
The class is already thread-safe:
- Marked `@unchecked Sendable`
- Uses `NSLock` for config access
- Already uses `GrammarManager.shared`

## Expected gain
5-20ms saved per code block after the first document load.

## Test plan
- [x] Build succeeds
- [x] Tests pass (9 pre-existing expected failures unchanged)

Closes #80