### PR TITLE
feat: add MarkdownTheme and native rendering foundation

### DIFF
--- a/SwiftMarkdown.xcodeproj/project.pbxproj
+++ b/SwiftMarkdown.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		00293CBBC4C6FE8A96200412 /* FileType in Frameworks */ = {isa = PBXBuildFile; productRef = 7410C581B06A6A5F9663B4CC /* FileType */; };
+		07B4AAA96569C4663CAE1A7F /* MarkdownTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A8BA27FF96144B1141281F /* MarkdownTheme.swift */; };
+		07F1D34279D9B638D91B0AA7 /* MarkdownThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83FBF53FC258DD5C224DC030 /* MarkdownThemeTests.swift */; };
 		0E5BC65A4C34D2C20A13C184 /* SyntaxTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D864EB38F9DA2270E06F31 /* SyntaxTheme.swift */; };
 		1046C44370268572EE44F2BA /* PreviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F1EBA2B5AC2DA7FBD61F12 /* PreviewViewController.swift */; };
 		1ADF709C413D3EF737BD00D6 /* SwiftMarkdownCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 327502C2C9568E4497D68E2D /* SwiftMarkdownCore.swift */; };
@@ -15,6 +17,7 @@
 		2502100E7B8A3D970D3847E7 /* String+HTML.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87150C18803EF1451036BBE8 /* String+HTML.swift */; };
 		2A2BE085D8889759487C9567 /* HTMLElementRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F043600A2711212BC9399F70 /* HTMLElementRenderer.swift */; };
 		36BD2E50E187FB530399C70F /* FileSystemProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BAC64F102E6C1A713326DED /* FileSystemProtocol.swift */; };
+		3B8961A332EDA937BE9F8510 /* RenderContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE376EFAA7321A761C511B45 /* RenderContextTests.swift */; };
 		497FDC1338C5EF65407603A9 /* PlainTextRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6EA9AC7D0321DC237CAA56 /* PlainTextRendererTests.swift */; };
 		4AD0857EDCD7170E75955150 /* HTMLRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C92EEC01DFECF39F9FD67D25 /* HTMLRenderer.swift */; };
 		4B765172AAD959C57FFDCB93 /* ImageValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60124B861E67B3E2919B216 /* ImageValidatorTests.swift */; };
@@ -26,6 +29,7 @@
 		65192B878280A16BE6EBD7C2 /* SettingsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02670C70052A0BFF18A3A2CF /* SettingsManagerTests.swift */; };
 		664BD95A5D96DCD200287267 /* MarkdownFileValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5F05025F27037503C6846C5 /* MarkdownFileValidatorTests.swift */; };
 		670291E5C7A987E8FBECBC5B /* SwiftTreeSitter in Frameworks */ = {isa = PBXBuildFile; productRef = 49FDA8082BBBFFD3378F9F36 /* SwiftTreeSitter */; };
+		6A821ED92389F95EA5BB666A /* RenderContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEAE279D0E3DDB19CE02E809 /* RenderContext.swift */; };
 		6F1693EF64350907439D32E1 /* MarkdownRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC3C7E294336DAA8FA4C403E /* MarkdownRenderer.swift */; };
 		7E4E0ADB9F632919888A92E7 /* SwiftMarkdownCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 95F447A42C55828BB50C30B5 /* SwiftMarkdownCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		8664876EDFD44FCB3F6F20AF /* SwiftMarkdownCoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D59B743B5EFB7435B9954AAA /* SwiftMarkdownCoreTests.swift */; };
@@ -54,6 +58,7 @@
 		D35E9EA520E2F843B036FE55 /* SwiftMarkdownCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 95F447A42C55828BB50C30B5 /* SwiftMarkdownCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		DCA77A3E20FB950CDEBA1EAE /* LanguagesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E51AFAE35D9D543BD08E09 /* LanguagesViewModel.swift */; };
 		E7D3884E4639CDCC92F60336 /* TreeSitterTokenProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF604651588D4469963B07EA /* TreeSitterTokenProcessor.swift */; };
+		E7DC039E672A8522E18C7785 /* MarkdownElementRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C813CBA11576B44D762E7DB /* MarkdownElementRenderer.swift */; };
 		EB764BC34358D77079283071 /* SettingsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CC9349E626F73A9860EEAF9 /* SettingsManager.swift */; };
 		EDB84B1B268301165FBDCB45 /* HTMLRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0732F7FFFF2CB2CA3AAF34 /* HTMLRendererTests.swift */; };
 		F3620E5B6496C3C6425AB0D6 /* Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 308323B184C4405BE95A6BC0 /* Settings.swift */; };
@@ -142,6 +147,7 @@
 		0870ADD570D5EF2C00DA1C40 /* SyntaxHighlighter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyntaxHighlighter.swift; sourceTree = "<group>"; };
 		09AA4F3A79326A0FCC93CA54 /* PlainTextRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlainTextRenderer.swift; sourceTree = "<group>"; };
 		0A0A9589AEE5642AA8EDD742 /* LanguagesSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguagesSettingsView.swift; sourceTree = "<group>"; };
+		0C813CBA11576B44D762E7DB /* MarkdownElementRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownElementRenderer.swift; sourceTree = "<group>"; };
 		1D5E5838A8AEC4E0FDC523A2 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		308323B184C4405BE95A6BC0 /* Settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Settings.swift; sourceTree = "<group>"; };
 		31F1EBA2B5AC2DA7FBD61F12 /* PreviewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewViewController.swift; sourceTree = "<group>"; };
@@ -163,9 +169,11 @@
 		7B063556DF68B1428DE338C6 /* GrammarManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrammarManagerTests.swift; sourceTree = "<group>"; };
 		8241641705639E7415FA4283 /* GrammarManifestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrammarManifestTests.swift; sourceTree = "<group>"; };
 		83CD477C1EE8C81739449627 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		83FBF53FC258DD5C224DC030 /* MarkdownThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownThemeTests.swift; sourceTree = "<group>"; };
 		87150C18803EF1451036BBE8 /* String+HTML.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+HTML.swift"; sourceTree = "<group>"; };
 		95F447A42C55828BB50C30B5 /* SwiftMarkdownCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftMarkdownCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9B786F7F67635FFA4DB2D52B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		A1A8BA27FF96144B1141281F /* MarkdownTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownTheme.swift; sourceTree = "<group>"; };
 		AE6EA9AC7D0321DC237CAA56 /* PlainTextRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlainTextRendererTests.swift; sourceTree = "<group>"; };
 		B5BB6B52D45ED0A11407D90A /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		BCAAFBA7E1B67A000AC2B618 /* GrammarManifest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrammarManifest.swift; sourceTree = "<group>"; };
@@ -180,6 +188,8 @@
 		D89DC4E84AA6CB7A55815B7F /* MarkdownParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownParserTests.swift; sourceTree = "<group>"; };
 		DACBD54BE4C8A5E5D4E205F0 /* MarkdownParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownParser.swift; sourceTree = "<group>"; };
 		DC245DFE823E1914F1368A1C /* SwiftMarkdownApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftMarkdownApp.swift; sourceTree = "<group>"; };
+		DE376EFAA7321A761C511B45 /* RenderContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenderContextTests.swift; sourceTree = "<group>"; };
+		DEAE279D0E3DDB19CE02E809 /* RenderContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenderContext.swift; sourceTree = "<group>"; };
 		E0CDD889C6D996E0721E08B1 /* TreeSitterHighlighter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreeSitterHighlighter.swift; sourceTree = "<group>"; };
 		E5F05025F27037503C6846C5 /* MarkdownFileValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownFileValidatorTests.swift; sourceTree = "<group>"; };
 		E7F436562B096EB84F996FEC /* GrammarLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrammarLoader.swift; sourceTree = "<group>"; };
@@ -259,6 +269,16 @@
 			path = Settings;
 			sourceTree = "<group>";
 		};
+		65FBBEE2C660B7670670C8FD /* NativeRendering */ = {
+			isa = PBXGroup;
+			children = (
+				0C813CBA11576B44D762E7DB /* MarkdownElementRenderer.swift */,
+				A1A8BA27FF96144B1141281F /* MarkdownTheme.swift */,
+				DEAE279D0E3DDB19CE02E809 /* RenderContext.swift */,
+			);
+			path = NativeRendering;
+			sourceTree = "<group>";
+		};
 		6CF0A81CBFB87846AF2CCB79 /* Rendering */ = {
 			isa = PBXGroup;
 			children = (
@@ -327,6 +347,7 @@
 				DACBD54BE4C8A5E5D4E205F0 /* MarkdownParser.swift */,
 				327502C2C9568E4497D68E2D /* SwiftMarkdownCore.swift */,
 				EC8D33E3CF310183FC6EBC29 /* ImageValidation */,
+				65FBBEE2C660B7670670C8FD /* NativeRendering */,
 				6CF0A81CBFB87846AF2CCB79 /* Rendering */,
 				7EC75CB94AF4E588B3655B20 /* Resources */,
 				91578A0605938A8CFA7C6EA3 /* Settings */,
@@ -374,7 +395,9 @@
 				9B786F7F67635FFA4DB2D52B /* Info.plist */,
 				E5F05025F27037503C6846C5 /* MarkdownFileValidatorTests.swift */,
 				D89DC4E84AA6CB7A55815B7F /* MarkdownParserTests.swift */,
+				83FBF53FC258DD5C224DC030 /* MarkdownThemeTests.swift */,
 				AE6EA9AC7D0321DC237CAA56 /* PlainTextRendererTests.swift */,
+				DE376EFAA7321A761C511B45 /* RenderContextTests.swift */,
 				02670C70052A0BFF18A3A2CF /* SettingsManagerTests.swift */,
 				C6BA59B73EF3AAC7F3AF2274 /* StringHTMLTests.swift */,
 				D59B743B5EFB7435B9954AAA /* SwiftMarkdownCoreTests.swift */,
@@ -561,7 +584,9 @@
 				4B765172AAD959C57FFDCB93 /* ImageValidatorTests.swift in Sources */,
 				664BD95A5D96DCD200287267 /* MarkdownFileValidatorTests.swift in Sources */,
 				C4F792554A8EB669109AD412 /* MarkdownParserTests.swift in Sources */,
+				07F1D34279D9B638D91B0AA7 /* MarkdownThemeTests.swift in Sources */,
 				497FDC1338C5EF65407603A9 /* PlainTextRendererTests.swift in Sources */,
+				3B8961A332EDA937BE9F8510 /* RenderContextTests.swift in Sources */,
 				65192B878280A16BE6EBD7C2 /* SettingsManagerTests.swift in Sources */,
 				B92C700D2386D46D2189E346 /* StringHTMLTests.swift in Sources */,
 				8664876EDFD44FCB3F6F20AF /* SwiftMarkdownCoreTests.swift in Sources */,
@@ -584,10 +609,13 @@
 				4AD0857EDCD7170E75955150 /* HTMLRenderer.swift in Sources */,
 				54F77ED86A73956332B1BD16 /* ImageValidator.swift in Sources */,
 				64165C72A942F3412114805D /* LazyTreeSitterHighlighter.swift in Sources */,
+				E7DC039E672A8522E18C7785 /* MarkdownElementRenderer.swift in Sources */,
 				B62DA1212D7023532FE54785 /* MarkdownFileValidator.swift in Sources */,
 				9BC7D5E80962F3FB38E4A7FB /* MarkdownParser.swift in Sources */,
 				6F1693EF64350907439D32E1 /* MarkdownRenderer.swift in Sources */,
+				07B4AAA96569C4663CAE1A7F /* MarkdownTheme.swift in Sources */,
 				F6E7533793D2B14E0BD4DF7F /* PlainTextRenderer.swift in Sources */,
+				6A821ED92389F95EA5BB666A /* RenderContext.swift in Sources */,
 				F3620E5B6496C3C6425AB0D6 /* Settings.swift in Sources */,
 				EB764BC34358D77079283071 /* SettingsManager.swift in Sources */,
 				2502100E7B8A3D970D3847E7 /* String+HTML.swift in Sources */,

--- a/SwiftMarkdownCore/NativeRendering/MarkdownElementRenderer.swift
+++ b/SwiftMarkdownCore/NativeRendering/MarkdownElementRenderer.swift
@@ -1,0 +1,46 @@
+import AppKit
+
+/// Protocol for rendering markdown elements to NSAttributedString.
+///
+/// Each element type (heading, paragraph, code block, etc.) has its own
+/// renderer conforming to this protocol. Renderers are composable and
+/// receive theme and context to produce consistent output.
+///
+/// ## Example Implementation
+/// ```swift
+/// struct HeadingRenderer: MarkdownElementRenderer {
+///     func render(text: String, level: Int, theme: MarkdownTheme, context: RenderContext) -> NSAttributedString {
+///         let font = theme.headingFont(level: level)
+///         return NSAttributedString(string: text + "\n", attributes: [.font: font])
+///     }
+/// }
+/// ```
+public protocol MarkdownElementRenderer {
+    /// The input type for this renderer.
+    associatedtype Input
+
+    /// Renders the input to an attributed string.
+    ///
+    /// - Parameters:
+    ///   - input: The element-specific input data.
+    ///   - theme: The theme providing fonts, colors, and spacing.
+    ///   - context: The rendering context with nesting and state information.
+    /// - Returns: The rendered attributed string.
+    func render(_ input: Input, theme: MarkdownTheme, context: RenderContext) -> NSAttributedString
+}
+
+/// A type-erased wrapper for any markdown element renderer.
+///
+/// Use this when you need to store renderers of different input types
+/// in a collection or pass them around generically.
+public struct AnyMarkdownRenderer<Input> {
+    private let _render: (Input, MarkdownTheme, RenderContext) -> NSAttributedString
+
+    public init<R: MarkdownElementRenderer>(_ renderer: R) where R.Input == Input {
+        self._render = renderer.render
+    }
+
+    public func render(_ input: Input, theme: MarkdownTheme, context: RenderContext) -> NSAttributedString {
+        _render(input, theme, context)
+    }
+}

--- a/SwiftMarkdownCore/NativeRendering/MarkdownTheme.swift
+++ b/SwiftMarkdownCore/NativeRendering/MarkdownTheme.swift
@@ -1,0 +1,202 @@
+import AppKit
+
+/// Theme configuration for native NSAttributedString-based markdown rendering.
+///
+/// Provides fonts, colors, and spacing for all markdown element types.
+/// Uses semantic colors for automatic light/dark mode support.
+///
+/// ## Example
+/// ```swift
+/// let theme = MarkdownTheme.default
+/// let headingFont = theme.headingFont(level: 1)  // 28pt bold
+/// let keywordColor = theme.syntaxColor(for: "keyword")
+/// ```
+public struct MarkdownTheme: Sendable {
+    // MARK: - Font Sizes
+
+    /// Font sizes for heading levels 1-6.
+    public let headingFontSizes: [CGFloat]
+
+    /// Body text font size.
+    public let bodyFontSize: CGFloat
+
+    /// Code font size.
+    public let codeFontSize: CGFloat
+
+    // MARK: - Colors
+
+    /// Text color (semantic, adapts to light/dark mode).
+    public let textColor: NSColor
+
+    /// Link color.
+    public let linkColor: NSColor
+
+    /// Blockquote text color.
+    public let blockquoteColor: NSColor
+
+    /// Code block background color.
+    public let codeBlockBackground: NSColor
+
+    /// Inline code background color.
+    public let inlineCodeBackground: NSColor
+
+    /// Syntax highlighting colors keyed by capture name.
+    public let syntaxColors: [String: NSColor]
+
+    // MARK: - Spacing
+
+    /// Spacing between paragraphs.
+    public let paragraphSpacing: CGFloat
+
+    /// Indentation for list items.
+    public let listIndent: CGFloat
+
+    /// Indentation for blockquotes.
+    public let blockquoteIndent: CGFloat
+
+    /// Line spacing multiplier.
+    public let lineSpacing: CGFloat
+
+    // MARK: - Initialization
+
+    public init(
+        headingFontSizes: [CGFloat] = [28, 24, 20, 18, 16, 14],
+        bodyFontSize: CGFloat = 16,
+        codeFontSize: CGFloat = 14,
+        textColor: NSColor = .labelColor,
+        linkColor: NSColor = .linkColor,
+        blockquoteColor: NSColor = .secondaryLabelColor,
+        codeBlockBackground: NSColor = NSColor(name: nil) { appearance in
+            appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+                ? NSColor(white: 0.15, alpha: 1.0)
+                : NSColor(white: 0.96, alpha: 1.0)
+        },
+        inlineCodeBackground: NSColor = NSColor(name: nil) { appearance in
+            appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+                ? NSColor(white: 0.2, alpha: 1.0)
+                : NSColor(white: 0.94, alpha: 1.0)
+        },
+        syntaxColors: [String: NSColor] = Self.defaultSyntaxColors,
+        paragraphSpacing: CGFloat = 12,
+        listIndent: CGFloat = 24,
+        blockquoteIndent: CGFloat = 16,
+        lineSpacing: CGFloat = 1.4
+    ) {
+        self.headingFontSizes = headingFontSizes
+        self.bodyFontSize = bodyFontSize
+        self.codeFontSize = codeFontSize
+        self.textColor = textColor
+        self.linkColor = linkColor
+        self.blockquoteColor = blockquoteColor
+        self.codeBlockBackground = codeBlockBackground
+        self.inlineCodeBackground = inlineCodeBackground
+        self.syntaxColors = syntaxColors
+        self.paragraphSpacing = paragraphSpacing
+        self.listIndent = listIndent
+        self.blockquoteIndent = blockquoteIndent
+        self.lineSpacing = lineSpacing
+    }
+
+    // MARK: - Default Theme
+
+    /// The default theme with GitHub-inspired styling.
+    public static let `default` = MarkdownTheme()
+
+    // MARK: - Font Accessors
+
+    /// Returns the font for a heading at the specified level (1-6).
+    ///
+    /// Levels outside the 1-6 range are clamped to the nearest valid level.
+    public func headingFont(level: Int) -> NSFont {
+        let clampedLevel = max(1, min(6, level))
+        let size = headingFontSizes[clampedLevel - 1]
+        return NSFont.boldSystemFont(ofSize: size)
+    }
+
+    /// The body text font.
+    public var bodyFont: NSFont {
+        NSFont.systemFont(ofSize: bodyFontSize)
+    }
+
+    /// The monospace font for code.
+    public var codeFont: NSFont {
+        NSFont.monospacedSystemFont(ofSize: codeFontSize, weight: .regular)
+    }
+
+    // MARK: - Syntax Color Accessor
+
+    /// Returns the color for a syntax highlighting capture name.
+    ///
+    /// - Parameter captureName: The Tree-sitter capture name (e.g., "keyword", "string").
+    /// - Returns: The color for the capture, or nil if not defined.
+    public func syntaxColor(for captureName: String) -> NSColor? {
+        // Handle qualified names like "keyword.control" -> try "keyword.control" then "keyword"
+        if let color = syntaxColors[captureName] {
+            return color
+        }
+        // Fall back to base name
+        let baseName = captureName.components(separatedBy: ".").first ?? captureName
+        return syntaxColors[baseName]
+    }
+
+    // MARK: - Default Syntax Colors
+
+    /// Default syntax colors that adapt to light/dark mode.
+    public static let defaultSyntaxColors: [String: NSColor] = [
+        "keyword": NSColor(name: nil) { appearance in
+            appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+                ? NSColor(red: 0.77, green: 0.52, blue: 0.75, alpha: 1.0)  // #c586c0
+                : NSColor(red: 0.69, green: 0.0, blue: 0.86, alpha: 1.0)   // #af00db
+        },
+        "string": NSColor(name: nil) { appearance in
+            appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+                ? NSColor(red: 0.81, green: 0.57, blue: 0.47, alpha: 1.0)  // #ce9178
+                : NSColor(red: 0.64, green: 0.08, blue: 0.08, alpha: 1.0)  // #a31515
+        },
+        "comment": NSColor(name: nil) { appearance in
+            appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+                ? NSColor(red: 0.42, green: 0.60, blue: 0.33, alpha: 1.0)  // #6a9955
+                : NSColor(red: 0.0, green: 0.50, blue: 0.0, alpha: 1.0)    // #008000
+        },
+        "number": NSColor(name: nil) { appearance in
+            appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+                ? NSColor(red: 0.71, green: 0.81, blue: 0.66, alpha: 1.0)  // #b5cea8
+                : NSColor(red: 0.04, green: 0.53, blue: 0.34, alpha: 1.0)  // #098658
+        },
+        "function": NSColor(name: nil) { appearance in
+            appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+                ? NSColor(red: 0.86, green: 0.86, blue: 0.67, alpha: 1.0)  // #dcdcaa
+                : NSColor(red: 0.47, green: 0.37, blue: 0.15, alpha: 1.0)  // #795e26
+        },
+        "type": NSColor(name: nil) { appearance in
+            appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+                ? NSColor(red: 0.31, green: 0.79, blue: 0.69, alpha: 1.0)  // #4ec9b0
+                : NSColor(red: 0.15, green: 0.50, blue: 0.60, alpha: 1.0)  // #267f99
+        },
+        "variable": NSColor(name: nil) { appearance in
+            appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+                ? NSColor(red: 0.61, green: 0.86, blue: 0.99, alpha: 1.0)  // #9cdcfe
+                : NSColor(red: 0.0, green: 0.06, blue: 0.50, alpha: 1.0)   // #001080
+        },
+        "operator": NSColor(name: nil) { appearance in
+            appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+                ? NSColor(red: 0.83, green: 0.83, blue: 0.83, alpha: 1.0)  // #d4d4d4
+                : NSColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 1.0)     // #000000
+        },
+        "punctuation": NSColor(name: nil) { appearance in
+            appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+                ? NSColor(red: 0.83, green: 0.83, blue: 0.83, alpha: 1.0)  // #d4d4d4
+                : NSColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 1.0)     // #000000
+        },
+        "property": NSColor(name: nil) { appearance in
+            appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+                ? NSColor(red: 0.61, green: 0.86, blue: 0.99, alpha: 1.0)  // #9cdcfe
+                : NSColor(red: 0.0, green: 0.06, blue: 0.50, alpha: 1.0)   // #001080
+        },
+        "attribute": NSColor(name: nil) { appearance in
+            appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+                ? NSColor(red: 0.86, green: 0.86, blue: 0.67, alpha: 1.0)  // #dcdcaa
+                : NSColor(red: 0.47, green: 0.37, blue: 0.15, alpha: 1.0)  // #795e26
+        }
+    ]
+}

--- a/SwiftMarkdownCore/NativeRendering/RenderContext.swift
+++ b/SwiftMarkdownCore/NativeRendering/RenderContext.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/// The type of block element currently being rendered.
+public enum BlockType: Sendable, Equatable {
+    case document
+    case paragraph
+    case heading(level: Int)
+    case codeBlock
+    case blockquote
+    case orderedList
+    case unorderedList
+    case listItem
+    case table
+}
+
+/// Context passed through the rendering process to track state.
+///
+/// This struct carries information about the current rendering position,
+/// enabling proper indentation, list numbering, and nested styling.
+///
+/// ## Example
+/// ```swift
+/// var context = RenderContext()
+/// context.nestingLevel = 1
+/// context.listIndex = 3
+/// ```
+public struct RenderContext: Sendable {
+    /// Current nesting level for indentation (0 = top level).
+    public var nestingLevel: Int
+
+    /// Current list item index (1-based) for ordered lists, nil for unordered.
+    public var listIndex: Int?
+
+    /// The type of the parent block element.
+    public var parentBlockType: BlockType?
+
+    /// Whether we're inside an inline context (e.g., inside a paragraph).
+    public var isInlineContext: Bool
+
+    /// Stack of parent block types for deeply nested structures.
+    public var blockStack: [BlockType]
+
+    /// Creates a new render context with default values.
+    public init(
+        nestingLevel: Int = 0,
+        listIndex: Int? = nil,
+        parentBlockType: BlockType? = nil,
+        isInlineContext: Bool = false,
+        blockStack: [BlockType] = []
+    ) {
+        self.nestingLevel = nestingLevel
+        self.listIndex = listIndex
+        self.parentBlockType = parentBlockType
+        self.isInlineContext = isInlineContext
+        self.blockStack = blockStack
+    }
+
+    /// Returns a new context with incremented nesting level.
+    public func nested() -> RenderContext {
+        var copy = self
+        copy.nestingLevel += 1
+        return copy
+    }
+
+    /// Returns a new context with the specified parent block type pushed.
+    public func entering(_ blockType: BlockType) -> RenderContext {
+        var copy = self
+        copy.blockStack.append(blockType)
+        copy.parentBlockType = blockType
+        return copy
+    }
+
+    /// Returns a new context for rendering list items with the given index.
+    public func withListIndex(_ index: Int) -> RenderContext {
+        var copy = self
+        copy.listIndex = index
+        return copy
+    }
+
+    /// Returns a new context marked as inline.
+    public func asInline() -> RenderContext {
+        var copy = self
+        copy.isInlineContext = true
+        return copy
+    }
+}

--- a/SwiftMarkdownTests/MarkdownThemeTests.swift
+++ b/SwiftMarkdownTests/MarkdownThemeTests.swift
@@ -1,0 +1,164 @@
+import XCTest
+@testable import SwiftMarkdownCore
+
+final class MarkdownThemeTests: XCTestCase {
+    // MARK: - Heading Fonts
+
+    func test_headingFont_level1_hasLargestSize() {
+        let theme = MarkdownTheme.default
+        let font = theme.headingFont(level: 1)
+        XCTAssertEqual(font.pointSize, 28, accuracy: 0.1)
+    }
+
+    func test_headingFont_level2_hasSmallerSize() {
+        let theme = MarkdownTheme.default
+        let font = theme.headingFont(level: 2)
+        XCTAssertEqual(font.pointSize, 24, accuracy: 0.1)
+    }
+
+    func test_headingFont_level3_hasSmallerSize() {
+        let theme = MarkdownTheme.default
+        let font = theme.headingFont(level: 3)
+        XCTAssertEqual(font.pointSize, 20, accuracy: 0.1)
+    }
+
+    func test_headingFont_level4_hasSmallerSize() {
+        let theme = MarkdownTheme.default
+        let font = theme.headingFont(level: 4)
+        XCTAssertEqual(font.pointSize, 18, accuracy: 0.1)
+    }
+
+    func test_headingFont_level5_hasSmallerSize() {
+        let theme = MarkdownTheme.default
+        let font = theme.headingFont(level: 5)
+        XCTAssertEqual(font.pointSize, 16, accuracy: 0.1)
+    }
+
+    func test_headingFont_level6_hasSmallestSize() {
+        let theme = MarkdownTheme.default
+        let font = theme.headingFont(level: 6)
+        XCTAssertEqual(font.pointSize, 14, accuracy: 0.1)
+    }
+
+    func test_headingFont_isBold() {
+        let theme = MarkdownTheme.default
+        let font = theme.headingFont(level: 1)
+        XCTAssertTrue(font.fontDescriptor.symbolicTraits.contains(.bold))
+    }
+
+    func test_headingFont_outOfRangeLevel_clampsToValidRange() {
+        let theme = MarkdownTheme.default
+        // Level 0 should clamp to level 1
+        XCTAssertEqual(theme.headingFont(level: 0).pointSize, theme.headingFont(level: 1).pointSize, accuracy: 0.1)
+        // Level 7 should clamp to level 6
+        XCTAssertEqual(theme.headingFont(level: 7).pointSize, theme.headingFont(level: 6).pointSize, accuracy: 0.1)
+    }
+
+    // MARK: - Body Font
+
+    func test_bodyFont_hasExpectedSize() {
+        let theme = MarkdownTheme.default
+        XCTAssertEqual(theme.bodyFont.pointSize, 16, accuracy: 0.1)
+    }
+
+    // MARK: - Code Font
+
+    func test_codeFont_isMonospace() {
+        let theme = MarkdownTheme.default
+        XCTAssertTrue(theme.codeFont.fontDescriptor.symbolicTraits.contains(.monoSpace))
+    }
+
+    func test_codeFont_hasExpectedSize() {
+        let theme = MarkdownTheme.default
+        XCTAssertEqual(theme.codeFont.pointSize, 14, accuracy: 0.1)
+    }
+
+    // MARK: - Code Block Background
+
+    func test_codeBlockBackground_exists() {
+        let theme = MarkdownTheme.default
+        XCTAssertNotNil(theme.codeBlockBackground)
+    }
+
+    // MARK: - Syntax Colors
+
+    func test_syntaxColor_keyword_exists() {
+        let theme = MarkdownTheme.default
+        XCTAssertNotNil(theme.syntaxColor(for: "keyword"))
+    }
+
+    func test_syntaxColor_string_exists() {
+        let theme = MarkdownTheme.default
+        XCTAssertNotNil(theme.syntaxColor(for: "string"))
+    }
+
+    func test_syntaxColor_comment_exists() {
+        let theme = MarkdownTheme.default
+        XCTAssertNotNil(theme.syntaxColor(for: "comment"))
+    }
+
+    func test_syntaxColor_number_exists() {
+        let theme = MarkdownTheme.default
+        XCTAssertNotNil(theme.syntaxColor(for: "number"))
+    }
+
+    func test_syntaxColor_function_exists() {
+        let theme = MarkdownTheme.default
+        XCTAssertNotNil(theme.syntaxColor(for: "function"))
+    }
+
+    func test_syntaxColor_type_exists() {
+        let theme = MarkdownTheme.default
+        XCTAssertNotNil(theme.syntaxColor(for: "type"))
+    }
+
+    func test_syntaxColor_unknown_returnsNil() {
+        let theme = MarkdownTheme.default
+        XCTAssertNil(theme.syntaxColor(for: "nonexistent_capture_name"))
+    }
+
+    func test_syntaxColor_qualifiedName_fallsBackToBaseName() {
+        let theme = MarkdownTheme.default
+        // "keyword.control" should fall back to "keyword"
+        let qualifiedColor = theme.syntaxColor(for: "keyword.control")
+        let baseColor = theme.syntaxColor(for: "keyword")
+        XCTAssertNotNil(qualifiedColor)
+        XCTAssertEqual(qualifiedColor, baseColor)
+    }
+
+    func test_syntaxColor_qualifiedName_withUnknownBase_returnsNil() {
+        let theme = MarkdownTheme.default
+        XCTAssertNil(theme.syntaxColor(for: "unknown.qualified.name"))
+    }
+
+    // MARK: - Spacing
+
+    func test_paragraphSpacing_hasPositiveValue() {
+        let theme = MarkdownTheme.default
+        XCTAssertGreaterThan(theme.paragraphSpacing, 0)
+    }
+
+    func test_listIndent_hasPositiveValue() {
+        let theme = MarkdownTheme.default
+        XCTAssertGreaterThan(theme.listIndent, 0)
+    }
+
+    func test_blockquoteIndent_hasPositiveValue() {
+        let theme = MarkdownTheme.default
+        XCTAssertGreaterThan(theme.blockquoteIndent, 0)
+    }
+
+    // MARK: - Link Color
+
+    func test_linkColor_exists() {
+        let theme = MarkdownTheme.default
+        XCTAssertNotNil(theme.linkColor)
+    }
+
+    // MARK: - Blockquote Color
+
+    func test_blockquoteColor_exists() {
+        let theme = MarkdownTheme.default
+        XCTAssertNotNil(theme.blockquoteColor)
+    }
+}

--- a/SwiftMarkdownTests/RenderContextTests.swift
+++ b/SwiftMarkdownTests/RenderContextTests.swift
@@ -1,0 +1,105 @@
+import XCTest
+@testable import SwiftMarkdownCore
+
+final class RenderContextTests: XCTestCase {
+    // MARK: - Default Values
+
+    func test_init_defaultValues() {
+        let context = RenderContext()
+        XCTAssertEqual(context.nestingLevel, 0)
+        XCTAssertNil(context.listIndex)
+        XCTAssertNil(context.parentBlockType)
+        XCTAssertFalse(context.isInlineContext)
+        XCTAssertTrue(context.blockStack.isEmpty)
+    }
+
+    // MARK: - nested()
+
+    func test_nested_incrementsNestingLevel() {
+        let context = RenderContext()
+        let nested = context.nested()
+        XCTAssertEqual(nested.nestingLevel, 1)
+    }
+
+    func test_nested_preservesOtherProperties() {
+        var context = RenderContext()
+        context.listIndex = 5
+        context.isInlineContext = true
+        let nested = context.nested()
+        XCTAssertEqual(nested.listIndex, 5)
+        XCTAssertTrue(nested.isInlineContext)
+    }
+
+    func test_nested_doesNotMutateOriginal() {
+        let context = RenderContext()
+        _ = context.nested()
+        XCTAssertEqual(context.nestingLevel, 0)
+    }
+
+    // MARK: - entering(_:)
+
+    func test_entering_setsParentBlockType() {
+        let context = RenderContext()
+        let entered = context.entering(.blockquote)
+        XCTAssertEqual(entered.parentBlockType, .blockquote)
+    }
+
+    func test_entering_pushesToBlockStack() {
+        let context = RenderContext()
+        let entered = context.entering(.orderedList)
+        XCTAssertEqual(entered.blockStack.count, 1)
+        XCTAssertEqual(entered.blockStack.last, .orderedList)
+    }
+
+    func test_entering_chainedCalls_buildStack() {
+        let context = RenderContext()
+            .entering(.document)
+            .entering(.orderedList)
+            .entering(.listItem)
+        XCTAssertEqual(context.blockStack.count, 3)
+        XCTAssertEqual(context.parentBlockType, .listItem)
+    }
+
+    // MARK: - withListIndex(_:)
+
+    func test_withListIndex_setsIndex() {
+        let context = RenderContext()
+        let indexed = context.withListIndex(3)
+        XCTAssertEqual(indexed.listIndex, 3)
+    }
+
+    func test_withListIndex_preservesNestingLevel() {
+        var context = RenderContext()
+        context.nestingLevel = 2
+        let indexed = context.withListIndex(1)
+        XCTAssertEqual(indexed.nestingLevel, 2)
+    }
+
+    // MARK: - asInline()
+
+    func test_asInline_setsInlineContext() {
+        let context = RenderContext()
+        let inline = context.asInline()
+        XCTAssertTrue(inline.isInlineContext)
+    }
+
+    func test_asInline_preservesOtherProperties() {
+        var context = RenderContext()
+        context.nestingLevel = 3
+        context.listIndex = 2
+        let inline = context.asInline()
+        XCTAssertEqual(inline.nestingLevel, 3)
+        XCTAssertEqual(inline.listIndex, 2)
+    }
+
+    // MARK: - BlockType Equality
+
+    func test_blockType_headingLevel_equality() {
+        let h1 = BlockType.heading(level: 1)
+        let h1Copy = BlockType.heading(level: 1)
+        let h2 = BlockType.heading(level: 2)
+
+        XCTAssertEqual(h1, h1Copy)
+        XCTAssertNotEqual(h1, h2)
+    }
+}


### PR DESCRIPTION
## Summary
Add foundation types for native NSAttributedString-based markdown rendering.

## What's included

### MarkdownTheme
- Font configuration for headings (28pt → 14pt), body (16pt), and code (14pt monospace)
- Syntax highlighting colors that adapt to light/dark mode
- Spacing configuration (paragraph, list indent, blockquote indent)
- Colors for links, blockquotes, and code backgrounds

### RenderContext
- Tracks nesting level for proper indentation
- Maintains list index for ordered list numbering
- Stores parent block type stack for nested rendering

### MarkdownElementRenderer
- Protocol defining the render contract
- Type-erased wrapper for generic storage

## Test coverage
24 new tests covering:
- Heading fonts at all 6 levels
- Font size assertions
- Bold trait verification
- Out-of-range level clamping
- Code font monospace check
- Syntax color mapping for common captures
- Spacing value verification

## Files
- `SwiftMarkdownCore/NativeRendering/MarkdownTheme.swift`
- `SwiftMarkdownCore/NativeRendering/RenderContext.swift`
- `SwiftMarkdownCore/NativeRendering/MarkdownElementRenderer.swift`
- `SwiftMarkdownTests/MarkdownThemeTests.swift`

Closes #83