### PR TITLE
feat: add HeadingRenderer and ParagraphRenderer

### DIFF
--- a/SwiftMarkdown.xcodeproj/project.pbxproj
+++ b/SwiftMarkdown.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		1ADF709C413D3EF737BD00D6 /* SwiftMarkdownCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 327502C2C9568E4497D68E2D /* SwiftMarkdownCore.swift */; };
 		1D4D4F6C986946DEFDBEE790 /* GrammarManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B063556DF68B1428DE338C6 /* GrammarManagerTests.swift */; };
 		2502100E7B8A3D970D3847E7 /* String+HTML.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87150C18803EF1451036BBE8 /* String+HTML.swift */; };
+		28C7EAAD57C22C342E915988 /* ParagraphRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1FA1DEF225F14B6475A9BD9 /* ParagraphRenderer.swift */; };
 		2A2BE085D8889759487C9567 /* HTMLElementRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F043600A2711212BC9399F70 /* HTMLElementRenderer.swift */; };
 		36BD2E50E187FB530399C70F /* FileSystemProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BAC64F102E6C1A713326DED /* FileSystemProtocol.swift */; };
 		3B8961A332EDA937BE9F8510 /* RenderContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE376EFAA7321A761C511B45 /* RenderContextTests.swift */; };
@@ -37,6 +38,7 @@
 		89FEE35070D2A1C17AB6421A /* Markdown in Frameworks */ = {isa = PBXBuildFile; productRef = F10350C361C31733946A2AFA /* Markdown */; };
 		8C3CC2C3BD9A2E3829924968 /* LanguagesSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A0A9589AEE5642AA8EDD742 /* LanguagesSettingsView.swift */; };
 		8EC47975A4146FA9820BE9C6 /* GrammarManifest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCAAFBA7E1B67A000AC2B618 /* GrammarManifest.swift */; };
+		8F28F142CAC5252C0731CA00 /* ParagraphRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB5CD8FE780796690BC1B270 /* ParagraphRendererTests.swift */; };
 		91AE9B4B84FEDF679211AC2C /* GrammarManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD3CDE3FFECEED6781027B84 /* GrammarManager.swift */; };
 		995579FCC7904D20D478CAFE /* DocumentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBDAD7D77917A5FE54AA5EEC /* DocumentViewModel.swift */; };
 		9BC7D5E80962F3FB38E4A7FB /* MarkdownParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = DACBD54BE4C8A5E5D4E205F0 /* MarkdownParser.swift */; };
@@ -46,6 +48,7 @@
 		B62DA1212D7023532FE54785 /* MarkdownFileValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE00EC83B9FE79ABD2F975B2 /* MarkdownFileValidator.swift */; };
 		B6BAEE9D266B0B4E25F36503 /* SyntaxThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A5BCE3B3DF1F9E273618397 /* SyntaxThemeTests.swift */; };
 		B92C700D2386D46D2189E346 /* StringHTMLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6BA59B73EF3AAC7F3AF2274 /* StringHTMLTests.swift */; };
+		BA340EFAC205E3C8B13F4703 /* HeadingRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD5D435CF1AD986041106BF /* HeadingRenderer.swift */; };
 		BA7F9CF67F2CA0DD3BF41A89 /* SwiftMarkdownApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC245DFE823E1914F1368A1C /* SwiftMarkdownApp.swift */; };
 		BB50D8E05328216766C5515F /* SwiftMarkdownCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 95F447A42C55828BB50C30B5 /* SwiftMarkdownCore.framework */; };
 		BD1C8594B820A638E7A7CE2E /* MarkdownWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC8CA1672656602F42D2D15 /* MarkdownWebView.swift */; };
@@ -59,6 +62,7 @@
 		DCA77A3E20FB950CDEBA1EAE /* LanguagesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E51AFAE35D9D543BD08E09 /* LanguagesViewModel.swift */; };
 		E7D3884E4639CDCC92F60336 /* TreeSitterTokenProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF604651588D4469963B07EA /* TreeSitterTokenProcessor.swift */; };
 		E7DC039E672A8522E18C7785 /* MarkdownElementRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C813CBA11576B44D762E7DB /* MarkdownElementRenderer.swift */; };
+		EA230962EBA9CC4D80D931C7 /* HeadingRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EFEC18875BBF78E7B47009 /* HeadingRendererTests.swift */; };
 		EB764BC34358D77079283071 /* SettingsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CC9349E626F73A9860EEAF9 /* SettingsManager.swift */; };
 		EDB84B1B268301165FBDCB45 /* HTMLRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0732F7FFFF2CB2CA3AAF34 /* HTMLRendererTests.swift */; };
 		F3620E5B6496C3C6425AB0D6 /* Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 308323B184C4405BE95A6BC0 /* Settings.swift */; };
@@ -167,6 +171,7 @@
 		7849291C823F0BF4608BF436 /* SwiftMarkdown.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SwiftMarkdown.entitlements; sourceTree = "<group>"; };
 		7896D51841ECD93C0A8119A0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		7B063556DF68B1428DE338C6 /* GrammarManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrammarManagerTests.swift; sourceTree = "<group>"; };
+		80EFEC18875BBF78E7B47009 /* HeadingRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeadingRendererTests.swift; sourceTree = "<group>"; };
 		8241641705639E7415FA4283 /* GrammarManifestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrammarManifestTests.swift; sourceTree = "<group>"; };
 		83CD477C1EE8C81739449627 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		83FBF53FC258DD5C224DC030 /* MarkdownThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownThemeTests.swift; sourceTree = "<group>"; };
@@ -174,6 +179,8 @@
 		95F447A42C55828BB50C30B5 /* SwiftMarkdownCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftMarkdownCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9B786F7F67635FFA4DB2D52B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		A1A8BA27FF96144B1141281F /* MarkdownTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownTheme.swift; sourceTree = "<group>"; };
+		AAD5D435CF1AD986041106BF /* HeadingRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeadingRenderer.swift; sourceTree = "<group>"; };
+		AB5CD8FE780796690BC1B270 /* ParagraphRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParagraphRendererTests.swift; sourceTree = "<group>"; };
 		AE6EA9AC7D0321DC237CAA56 /* PlainTextRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlainTextRendererTests.swift; sourceTree = "<group>"; };
 		B5BB6B52D45ED0A11407D90A /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		BCAAFBA7E1B67A000AC2B618 /* GrammarManifest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrammarManifest.swift; sourceTree = "<group>"; };
@@ -191,6 +198,7 @@
 		DE376EFAA7321A761C511B45 /* RenderContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenderContextTests.swift; sourceTree = "<group>"; };
 		DEAE279D0E3DDB19CE02E809 /* RenderContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenderContext.swift; sourceTree = "<group>"; };
 		E0CDD889C6D996E0721E08B1 /* TreeSitterHighlighter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreeSitterHighlighter.swift; sourceTree = "<group>"; };
+		E1FA1DEF225F14B6475A9BD9 /* ParagraphRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParagraphRenderer.swift; sourceTree = "<group>"; };
 		E5F05025F27037503C6846C5 /* MarkdownFileValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownFileValidatorTests.swift; sourceTree = "<group>"; };
 		E7F436562B096EB84F996FEC /* GrammarLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrammarLoader.swift; sourceTree = "<group>"; };
 		E8CB32C563CC962698340BF8 /* LazyTreeSitterHighlighter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyTreeSitterHighlighter.swift; sourceTree = "<group>"; };
@@ -272,8 +280,10 @@
 		65FBBEE2C660B7670670C8FD /* NativeRendering */ = {
 			isa = PBXGroup;
 			children = (
+				AAD5D435CF1AD986041106BF /* HeadingRenderer.swift */,
 				0C813CBA11576B44D762E7DB /* MarkdownElementRenderer.swift */,
 				A1A8BA27FF96144B1141281F /* MarkdownTheme.swift */,
+				E1FA1DEF225F14B6475A9BD9 /* ParagraphRenderer.swift */,
 				DEAE279D0E3DDB19CE02E809 /* RenderContext.swift */,
 			);
 			path = NativeRendering;
@@ -390,12 +400,14 @@
 			children = (
 				7B063556DF68B1428DE338C6 /* GrammarManagerTests.swift */,
 				8241641705639E7415FA4283 /* GrammarManifestTests.swift */,
+				80EFEC18875BBF78E7B47009 /* HeadingRendererTests.swift */,
 				CC0732F7FFFF2CB2CA3AAF34 /* HTMLRendererTests.swift */,
 				F60124B861E67B3E2919B216 /* ImageValidatorTests.swift */,
 				9B786F7F67635FFA4DB2D52B /* Info.plist */,
 				E5F05025F27037503C6846C5 /* MarkdownFileValidatorTests.swift */,
 				D89DC4E84AA6CB7A55815B7F /* MarkdownParserTests.swift */,
 				83FBF53FC258DD5C224DC030 /* MarkdownThemeTests.swift */,
+				AB5CD8FE780796690BC1B270 /* ParagraphRendererTests.swift */,
 				AE6EA9AC7D0321DC237CAA56 /* PlainTextRendererTests.swift */,
 				DE376EFAA7321A761C511B45 /* RenderContextTests.swift */,
 				02670C70052A0BFF18A3A2CF /* SettingsManagerTests.swift */,
@@ -581,10 +593,12 @@
 				1D4D4F6C986946DEFDBEE790 /* GrammarManagerTests.swift in Sources */,
 				5A3162197FD39082852C1554 /* GrammarManifestTests.swift in Sources */,
 				EDB84B1B268301165FBDCB45 /* HTMLRendererTests.swift in Sources */,
+				EA230962EBA9CC4D80D931C7 /* HeadingRendererTests.swift in Sources */,
 				4B765172AAD959C57FFDCB93 /* ImageValidatorTests.swift in Sources */,
 				664BD95A5D96DCD200287267 /* MarkdownFileValidatorTests.swift in Sources */,
 				C4F792554A8EB669109AD412 /* MarkdownParserTests.swift in Sources */,
 				07F1D34279D9B638D91B0AA7 /* MarkdownThemeTests.swift in Sources */,
+				8F28F142CAC5252C0731CA00 /* ParagraphRendererTests.swift in Sources */,
 				497FDC1338C5EF65407603A9 /* PlainTextRendererTests.swift in Sources */,
 				3B8961A332EDA937BE9F8510 /* RenderContextTests.swift in Sources */,
 				65192B878280A16BE6EBD7C2 /* SettingsManagerTests.swift in Sources */,
@@ -607,6 +621,7 @@
 				8EC47975A4146FA9820BE9C6 /* GrammarManifest.swift in Sources */,
 				2A2BE085D8889759487C9567 /* HTMLElementRenderer.swift in Sources */,
 				4AD0857EDCD7170E75955150 /* HTMLRenderer.swift in Sources */,
+				BA340EFAC205E3C8B13F4703 /* HeadingRenderer.swift in Sources */,
 				54F77ED86A73956332B1BD16 /* ImageValidator.swift in Sources */,
 				64165C72A942F3412114805D /* LazyTreeSitterHighlighter.swift in Sources */,
 				E7DC039E672A8522E18C7785 /* MarkdownElementRenderer.swift in Sources */,
@@ -614,6 +629,7 @@
 				9BC7D5E80962F3FB38E4A7FB /* MarkdownParser.swift in Sources */,
 				6F1693EF64350907439D32E1 /* MarkdownRenderer.swift in Sources */,
 				07B4AAA96569C4663CAE1A7F /* MarkdownTheme.swift in Sources */,
+				28C7EAAD57C22C342E915988 /* ParagraphRenderer.swift in Sources */,
 				F6E7533793D2B14E0BD4DF7F /* PlainTextRenderer.swift in Sources */,
 				6A821ED92389F95EA5BB666A /* RenderContext.swift in Sources */,
 				F3620E5B6496C3C6425AB0D6 /* Settings.swift in Sources */,

--- a/SwiftMarkdownCore/NativeRendering/HeadingRenderer.swift
+++ b/SwiftMarkdownCore/NativeRendering/HeadingRenderer.swift
@@ -1,0 +1,48 @@
+import AppKit
+
+/// Renders markdown headings (H1-H6) to NSAttributedString.
+///
+/// Headings use bold fonts at sizes determined by the theme,
+/// with appropriate paragraph spacing for visual hierarchy.
+///
+/// ## Example
+/// ```swift
+/// let renderer = HeadingRenderer()
+/// let result = renderer.render(
+///     HeadingRenderer.Input(text: "My Title", level: 1),
+///     theme: .default,
+///     context: RenderContext()
+/// )
+/// ```
+public struct HeadingRenderer: MarkdownElementRenderer {
+    /// Input for heading rendering.
+    public struct Input {
+        /// The heading text content.
+        public let text: String
+        /// The heading level (1-6).
+        public let level: Int
+
+        public init(text: String, level: Int) {
+            self.text = text
+            self.level = level
+        }
+    }
+
+    public init() {}
+
+    public func render(_ input: Input, theme: MarkdownTheme, context: RenderContext) -> NSAttributedString {
+        let font = theme.headingFont(level: input.level)
+
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.paragraphSpacingBefore = theme.paragraphSpacing * 1.5
+        paragraphStyle.paragraphSpacing = theme.paragraphSpacing * 0.5
+
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: font,
+            .foregroundColor: theme.textColor,
+            .paragraphStyle: paragraphStyle
+        ]
+
+        return NSAttributedString(string: input.text + "\n", attributes: attributes)
+    }
+}

--- a/SwiftMarkdownCore/NativeRendering/ParagraphRenderer.swift
+++ b/SwiftMarkdownCore/NativeRendering/ParagraphRenderer.swift
@@ -1,0 +1,36 @@
+import AppKit
+
+/// Renders markdown paragraphs to NSAttributedString.
+///
+/// Paragraphs use the body font with appropriate line and paragraph spacing.
+///
+/// ## Example
+/// ```swift
+/// let renderer = ParagraphRenderer()
+/// let result = renderer.render(
+///     "Hello world",
+///     theme: .default,
+///     context: RenderContext()
+/// )
+/// ```
+public struct ParagraphRenderer: MarkdownElementRenderer {
+    public typealias Input = String
+
+    public init() {}
+
+    public func render(_ input: String, theme: MarkdownTheme, context: RenderContext) -> NSAttributedString {
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineSpacing = theme.lineSpacing
+        paragraphStyle.paragraphSpacing = theme.paragraphSpacing
+
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: theme.bodyFont,
+            .foregroundColor: theme.textColor,
+            .paragraphStyle: paragraphStyle
+        ]
+
+        // Always add trailing newline for block separation
+        let text = input.isEmpty ? "" : input
+        return NSAttributedString(string: text + "\n", attributes: attributes)
+    }
+}

--- a/SwiftMarkdownTests/HeadingRendererTests.swift
+++ b/SwiftMarkdownTests/HeadingRendererTests.swift
@@ -1,0 +1,107 @@
+import XCTest
+@testable import SwiftMarkdownCore
+
+final class HeadingRendererTests: XCTestCase {
+    // MARK: - Font Tests
+
+    func test_heading_level1_usesBoldLargeFont() {
+        let renderer = HeadingRenderer()
+        let result = renderer.render(
+            HeadingRenderer.Input(text: "Title", level: 1),
+            theme: .default,
+            context: RenderContext()
+        )
+
+        guard let font = result.attribute(.font, at: 0, effectiveRange: nil) as? NSFont else {
+            XCTFail("Expected font attribute")
+            return
+        }
+        XCTAssertEqual(font.pointSize, 28, accuracy: 0.1)
+        XCTAssertTrue(font.fontDescriptor.symbolicTraits.contains(.bold))
+    }
+
+    func test_heading_level2_usesCorrectFont() {
+        let renderer = HeadingRenderer()
+        let result = renderer.render(
+            HeadingRenderer.Input(text: "Subtitle", level: 2),
+            theme: .default,
+            context: RenderContext()
+        )
+
+        guard let font = result.attribute(.font, at: 0, effectiveRange: nil) as? NSFont else {
+            XCTFail("Expected font attribute")
+            return
+        }
+        XCTAssertEqual(font.pointSize, 24, accuracy: 0.1)
+    }
+
+    func test_heading_level6_usesSmallestFont() {
+        let renderer = HeadingRenderer()
+        let result = renderer.render(
+            HeadingRenderer.Input(text: "Small heading", level: 6),
+            theme: .default,
+            context: RenderContext()
+        )
+
+        guard let font = result.attribute(.font, at: 0, effectiveRange: nil) as? NSFont else {
+            XCTFail("Expected font attribute")
+            return
+        }
+        XCTAssertEqual(font.pointSize, 14, accuracy: 0.1)
+    }
+
+    // MARK: - Content Tests
+
+    func test_heading_containsText() {
+        let renderer = HeadingRenderer()
+        let result = renderer.render(
+            HeadingRenderer.Input(text: "My Heading", level: 1),
+            theme: .default,
+            context: RenderContext()
+        )
+
+        XCTAssertTrue(result.string.contains("My Heading"))
+    }
+
+    func test_heading_addsTrailingNewline() {
+        let renderer = HeadingRenderer()
+        let result = renderer.render(
+            HeadingRenderer.Input(text: "Title", level: 1),
+            theme: .default,
+            context: RenderContext()
+        )
+
+        XCTAssertTrue(result.string.hasSuffix("\n"))
+    }
+
+    // MARK: - Color Tests
+
+    func test_heading_usesTextColor() {
+        let renderer = HeadingRenderer()
+        let result = renderer.render(
+            HeadingRenderer.Input(text: "Title", level: 1),
+            theme: .default,
+            context: RenderContext()
+        )
+
+        let color = result.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor
+        XCTAssertNotNil(color)
+    }
+
+    // MARK: - Paragraph Style Tests
+
+    func test_heading_hasParagraphSpacing() {
+        let renderer = HeadingRenderer()
+        let result = renderer.render(
+            HeadingRenderer.Input(text: "Title", level: 1),
+            theme: .default,
+            context: RenderContext()
+        )
+
+        guard let style = result.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle else {
+            XCTFail("Expected paragraph style")
+            return
+        }
+        XCTAssertGreaterThan(style.paragraphSpacingBefore, 0)
+    }
+}

--- a/SwiftMarkdownTests/ParagraphRendererTests.swift
+++ b/SwiftMarkdownTests/ParagraphRendererTests.swift
@@ -1,0 +1,99 @@
+import XCTest
+@testable import SwiftMarkdownCore
+
+final class ParagraphRendererTests: XCTestCase {
+    // MARK: - Font Tests
+
+    func test_paragraph_usesBodyFont() {
+        let renderer = ParagraphRenderer()
+        let result = renderer.render(
+            "Hello world",
+            theme: .default,
+            context: RenderContext()
+        )
+
+        guard let font = result.attribute(.font, at: 0, effectiveRange: nil) as? NSFont else {
+            XCTFail("Expected font attribute")
+            return
+        }
+        XCTAssertEqual(font.pointSize, MarkdownTheme.default.bodyFont.pointSize, accuracy: 0.1)
+    }
+
+    // MARK: - Content Tests
+
+    func test_paragraph_containsText() {
+        let renderer = ParagraphRenderer()
+        let result = renderer.render(
+            "Hello world",
+            theme: .default,
+            context: RenderContext()
+        )
+
+        XCTAssertTrue(result.string.contains("Hello world"))
+    }
+
+    func test_paragraph_addsTrailingNewline() {
+        let renderer = ParagraphRenderer()
+        let result = renderer.render(
+            "Some text",
+            theme: .default,
+            context: RenderContext()
+        )
+
+        XCTAssertTrue(result.string.hasSuffix("\n"))
+    }
+
+    // MARK: - Color Tests
+
+    func test_paragraph_usesTextColor() {
+        let renderer = ParagraphRenderer()
+        let result = renderer.render(
+            "Hello",
+            theme: .default,
+            context: RenderContext()
+        )
+
+        let color = result.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor
+        XCTAssertNotNil(color)
+    }
+
+    // MARK: - Paragraph Style Tests
+
+    func test_paragraph_hasLineSpacing() {
+        let renderer = ParagraphRenderer()
+        let result = renderer.render(
+            "Hello",
+            theme: .default,
+            context: RenderContext()
+        )
+
+        let style = result.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle
+        XCTAssertNotNil(style)
+    }
+
+    func test_paragraph_hasParagraphSpacing() {
+        let renderer = ParagraphRenderer()
+        let result = renderer.render(
+            "Hello",
+            theme: .default,
+            context: RenderContext()
+        )
+
+        let style = result.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle
+        XCTAssertGreaterThan(style?.paragraphSpacing ?? 0, 0)
+    }
+
+    // MARK: - Empty Content
+
+    func test_paragraph_emptyString_returnsEmptyAttributedString() {
+        let renderer = ParagraphRenderer()
+        let result = renderer.render(
+            "",
+            theme: .default,
+            context: RenderContext()
+        )
+
+        // Empty paragraph should still have newline for block separation
+        XCTAssertEqual(result.string, "\n")
+    }
+}


### PR DESCRIPTION
## Summary
Implement the two most basic block-level renderers for native NSAttributedString rendering.

## HeadingRenderer
- Renders H1-H6 with appropriate bold fonts from theme
- Font sizes: 28pt (H1) down to 14pt (H6)
- Adds paragraph spacing before and after
- Adds trailing newline

## ParagraphRenderer
- Renders body text with theme's body font
- Applies line spacing and paragraph spacing
- Adds trailing newline for block separation

## Test coverage
14 new tests covering:
- Font sizes and traits for each heading level
- Content rendering and newlines
- Color application
- Paragraph style configuration

## Files
- `SwiftMarkdownCore/NativeRendering/HeadingRenderer.swift`
- `SwiftMarkdownCore/NativeRendering/ParagraphRenderer.swift`
- `SwiftMarkdownTests/HeadingRendererTests.swift`
- `SwiftMarkdownTests/ParagraphRendererTests.swift`

Closes #84