### PR TITLE
feat: add CodeBlockRenderer with Tree-sitter syntax highlighting support

### DIFF
--- a/SwiftMarkdown.xcodeproj/project.pbxproj
+++ b/SwiftMarkdown.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0009EB03C15B74FED0F85D93 /* CodeBlockRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612239001FD5DED5060CBE48 /* CodeBlockRenderer.swift */; };
 		00293CBBC4C6FE8A96200412 /* FileType in Frameworks */ = {isa = PBXBuildFile; productRef = 7410C581B06A6A5F9663B4CC /* FileType */; };
 		07B4AAA96569C4663CAE1A7F /* MarkdownTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A8BA27FF96144B1141281F /* MarkdownTheme.swift */; };
 		07F1D34279D9B638D91B0AA7 /* MarkdownThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83FBF53FC258DD5C224DC030 /* MarkdownThemeTests.swift */; };
@@ -25,6 +26,7 @@
 		4AD0857EDCD7170E75955150 /* HTMLRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C92EEC01DFECF39F9FD67D25 /* HTMLRenderer.swift */; };
 		4B765172AAD959C57FFDCB93 /* ImageValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60124B861E67B3E2919B216 /* ImageValidatorTests.swift */; };
 		54F77ED86A73956332B1BD16 /* ImageValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E01F16278E86C893DE1324F /* ImageValidator.swift */; };
+		56D9CF15EB83D8C20BC0A36E /* CodeBlockRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A622678EECA60D591402AC63 /* CodeBlockRendererTests.swift */; };
 		5A3162197FD39082852C1554 /* GrammarManifestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8241641705639E7415FA4283 /* GrammarManifestTests.swift */; };
 		5DEBE8F448112FD03EE248BD /* TreeSitterHighlighter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0CDD889C6D996E0721E08B1 /* TreeSitterHighlighter.swift */; };
 		6369C1964EA36F2BFAD11691 /* highlight.css in Resources */ = {isa = PBXBuildFile; fileRef = 42761C721193A258C1ABC5E4 /* highlight.css */; };
@@ -178,6 +180,7 @@
 		5BAC64F102E6C1A713326DED /* FileSystemProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSystemProtocol.swift; sourceTree = "<group>"; };
 		5CC9349E626F73A9860EEAF9 /* SettingsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsManager.swift; sourceTree = "<group>"; };
 		60DAB9333ACF98FC398657DF /* AsyncHTMLWalker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncHTMLWalker.swift; sourceTree = "<group>"; };
+		612239001FD5DED5060CBE48 /* CodeBlockRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeBlockRenderer.swift; sourceTree = "<group>"; };
 		6567C09B42A4181208919050 /* SwiftMarkdownQuickLook.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = SwiftMarkdownQuickLook.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		7130A40117A04774C2B20CA6 /* InlineCodeRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineCodeRenderer.swift; sourceTree = "<group>"; };
 		7849291C823F0BF4608BF436 /* SwiftMarkdown.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SwiftMarkdown.entitlements; sourceTree = "<group>"; };
@@ -193,6 +196,7 @@
 		95F447A42C55828BB50C30B5 /* SwiftMarkdownCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftMarkdownCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9B786F7F67635FFA4DB2D52B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		A1A8BA27FF96144B1141281F /* MarkdownTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownTheme.swift; sourceTree = "<group>"; };
+		A622678EECA60D591402AC63 /* CodeBlockRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeBlockRendererTests.swift; sourceTree = "<group>"; };
 		AAD5D435CF1AD986041106BF /* HeadingRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeadingRenderer.swift; sourceTree = "<group>"; };
 		AB5CD8FE780796690BC1B270 /* ParagraphRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParagraphRendererTests.swift; sourceTree = "<group>"; };
 		AE6EA9AC7D0321DC237CAA56 /* PlainTextRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlainTextRendererTests.swift; sourceTree = "<group>"; };
@@ -296,6 +300,7 @@
 		65FBBEE2C660B7670670C8FD /* NativeRendering */ = {
 			isa = PBXGroup;
 			children = (
+				612239001FD5DED5060CBE48 /* CodeBlockRenderer.swift */,
 				7954C82A1FB5381C3ABE0707 /* EmphasisRenderer.swift */,
 				AAD5D435CF1AD986041106BF /* HeadingRenderer.swift */,
 				7130A40117A04774C2B20CA6 /* InlineCodeRenderer.swift */,
@@ -418,6 +423,7 @@
 		EE46B3B0894560244A3035ED /* SwiftMarkdownTests */ = {
 			isa = PBXGroup;
 			children = (
+				A622678EECA60D591402AC63 /* CodeBlockRendererTests.swift */,
 				F4D05EB02BCC6049F8103278 /* EmphasisRendererTests.swift */,
 				7B063556DF68B1428DE338C6 /* GrammarManagerTests.swift */,
 				8241641705639E7415FA4283 /* GrammarManifestTests.swift */,
@@ -614,6 +620,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				56D9CF15EB83D8C20BC0A36E /* CodeBlockRendererTests.swift in Sources */,
 				9CA4F91A86112062D1F0CE34 /* EmphasisRendererTests.swift in Sources */,
 				1D4D4F6C986946DEFDBEE790 /* GrammarManagerTests.swift in Sources */,
 				5A3162197FD39082852C1554 /* GrammarManifestTests.swift in Sources */,
@@ -642,6 +649,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BFA78EFE0811FC9BB1CCA532 /* AsyncHTMLWalker.swift in Sources */,
+				0009EB03C15B74FED0F85D93 /* CodeBlockRenderer.swift in Sources */,
 				C32DCDDECDFF9724F53C0D2C /* EmphasisRenderer.swift in Sources */,
 				36BD2E50E187FB530399C70F /* FileSystemProtocol.swift in Sources */,
 				BD9282D7285DD285D40B7411 /* GrammarError.swift in Sources */,

--- a/SwiftMarkdownCore/NativeRendering/CodeBlockRenderer.swift
+++ b/SwiftMarkdownCore/NativeRendering/CodeBlockRenderer.swift
@@ -1,0 +1,103 @@
+import AppKit
+
+/// Renders fenced code blocks to NSAttributedString with optional syntax highlighting.
+///
+/// Code blocks use monospace font with a background color. When a highlighter
+/// is provided and a language is specified, syntax colors are applied based
+/// on the token types.
+///
+/// ## Example
+/// ```swift
+/// // Without highlighting
+/// let renderer = CodeBlockRenderer()
+/// let result = renderer.render(
+///     CodeBlockRenderer.Input(code: "let x = 1", language: nil),
+///     theme: .default,
+///     context: RenderContext()
+/// )
+///
+/// // With highlighting
+/// let highlighter = LazyTreeSitterHighlighter.shared
+/// let renderer = CodeBlockRenderer(highlighter: highlighter)
+/// let result = renderer.render(
+///     CodeBlockRenderer.Input(code: "let x = 1", language: "swift"),
+///     theme: .default,
+///     context: RenderContext()
+/// )
+/// ```
+public struct CodeBlockRenderer: MarkdownElementRenderer {
+    /// Input for code block rendering.
+    public struct Input {
+        /// The code content.
+        public let code: String
+        /// The language identifier for syntax highlighting (e.g., "swift").
+        public let language: String?
+
+        public init(code: String, language: String?) {
+            self.code = code
+            self.language = language
+        }
+    }
+
+    private let highlighter: (any SyntaxHighlighter)?
+
+    /// Creates a code block renderer.
+    ///
+    /// - Parameter highlighter: Optional syntax highlighter for colorizing code.
+    public init(highlighter: (any SyntaxHighlighter)? = nil) {
+        self.highlighter = highlighter
+    }
+
+    public func render(_ input: Input, theme: MarkdownTheme, context: RenderContext) -> NSAttributedString {
+        let code = input.code.isEmpty ? "" : input.code
+
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineSpacing = 0
+
+        // Base attributes for all code
+        let baseAttributes: [NSAttributedString.Key: Any] = [
+            .font: theme.codeFont,
+            .foregroundColor: theme.textColor,
+            .backgroundColor: theme.codeBlockBackground,
+            .paragraphStyle: paragraphStyle
+        ]
+
+        // Create the base attributed string with trailing newline
+        let result = NSMutableAttributedString(string: code + "\n", attributes: baseAttributes)
+
+        // Apply syntax highlighting if available
+        if let language = input.language,
+           let highlighter = highlighter {
+            let tokens = highlighter.highlight(code: code, language: language)
+            applySyntaxColors(tokens: tokens, to: result, code: code, theme: theme)
+        }
+
+        return result
+    }
+
+    private func applySyntaxColors(
+        tokens: [HighlightToken],
+        to attributedString: NSMutableAttributedString,
+        code: String,
+        theme: MarkdownTheme
+    ) {
+        for token in tokens {
+            guard let color = theme.syntaxColor(for: token.tokenType.rawValue) else {
+                continue
+            }
+
+            // Convert String.Index range to NSRange
+            let start = code.distance(from: code.startIndex, to: token.range.lowerBound)
+            let length = code.distance(from: token.range.lowerBound, to: token.range.upperBound)
+            let nsRange = NSRange(location: start, length: length)
+
+            // Ensure range is valid
+            guard nsRange.location >= 0,
+                  nsRange.location + nsRange.length <= attributedString.length else {
+                continue
+            }
+
+            attributedString.addAttribute(.foregroundColor, value: color, range: nsRange)
+        }
+    }
+}

--- a/SwiftMarkdownTests/CodeBlockRendererTests.swift
+++ b/SwiftMarkdownTests/CodeBlockRendererTests.swift
@@ -1,0 +1,225 @@
+import XCTest
+@testable import SwiftMarkdownCore
+
+final class CodeBlockRendererTests: XCTestCase {
+    // MARK: - Font Tests
+
+    func test_codeBlock_usesMonospaceFont() {
+        let renderer = CodeBlockRenderer()
+        let result = renderer.render(
+            CodeBlockRenderer.Input(code: "let x = 1", language: nil),
+            theme: .default,
+            context: RenderContext()
+        )
+
+        guard let font = result.attribute(.font, at: 0, effectiveRange: nil) as? NSFont else {
+            XCTFail("Expected font attribute")
+            return
+        }
+        XCTAssertTrue(font.fontDescriptor.symbolicTraits.contains(.monoSpace))
+    }
+
+    func test_codeBlock_usesThemeCodeFontSize() {
+        let renderer = CodeBlockRenderer()
+        let result = renderer.render(
+            CodeBlockRenderer.Input(code: "code", language: nil),
+            theme: .default,
+            context: RenderContext()
+        )
+
+        guard let font = result.attribute(.font, at: 0, effectiveRange: nil) as? NSFont else {
+            XCTFail("Expected font attribute")
+            return
+        }
+        XCTAssertEqual(font.pointSize, MarkdownTheme.default.codeFontSize, accuracy: 0.1)
+    }
+
+    // MARK: - Background Color Tests
+
+    func test_codeBlock_hasBackgroundColor() {
+        let renderer = CodeBlockRenderer()
+        let result = renderer.render(
+            CodeBlockRenderer.Input(code: "x", language: nil),
+            theme: .default,
+            context: RenderContext()
+        )
+
+        let backgroundColor = result.attribute(.backgroundColor, at: 0, effectiveRange: nil) as? NSColor
+        XCTAssertNotNil(backgroundColor)
+    }
+
+    func test_codeBlock_backgroundSpansEntireCode() {
+        let renderer = CodeBlockRenderer()
+        let result = renderer.render(
+            CodeBlockRenderer.Input(code: "line one\nline two", language: nil),
+            theme: .default,
+            context: RenderContext()
+        )
+
+        var range = NSRange(location: 0, length: 0)
+        _ = result.attribute(.backgroundColor, at: 0, effectiveRange: &range)
+        XCTAssertEqual(range.length, result.length)
+    }
+
+    // MARK: - Content Tests
+
+    func test_codeBlock_preservesWhitespace() {
+        let renderer = CodeBlockRenderer()
+        let code = "line1\n  indented\n    more\nline4"
+        let result = renderer.render(
+            CodeBlockRenderer.Input(code: code, language: nil),
+            theme: .default,
+            context: RenderContext()
+        )
+
+        XCTAssertTrue(result.string.hasPrefix(code))
+    }
+
+    func test_codeBlock_addsTrailingNewline() {
+        let renderer = CodeBlockRenderer()
+        let result = renderer.render(
+            CodeBlockRenderer.Input(code: "code", language: nil),
+            theme: .default,
+            context: RenderContext()
+        )
+
+        XCTAssertTrue(result.string.hasSuffix("\n"))
+    }
+
+    func test_codeBlock_emptyCode_returnsNewlineOnly() {
+        let renderer = CodeBlockRenderer()
+        let result = renderer.render(
+            CodeBlockRenderer.Input(code: "", language: nil),
+            theme: .default,
+            context: RenderContext()
+        )
+
+        XCTAssertEqual(result.string, "\n")
+    }
+
+    // MARK: - Text Color Tests
+
+    func test_codeBlock_usesTextColor() {
+        let renderer = CodeBlockRenderer()
+        let result = renderer.render(
+            CodeBlockRenderer.Input(code: "code", language: nil),
+            theme: .default,
+            context: RenderContext()
+        )
+
+        let color = result.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor
+        XCTAssertNotNil(color)
+    }
+
+    // MARK: - Syntax Highlighting Tests
+
+    func test_codeBlock_withHighlighter_appliesSyntaxColors() {
+        let code = "let x = 1"
+        let mockHighlighter = MockSyntaxHighlighter(tokens: [
+            HighlightToken(
+                range: code.startIndex..<code.index(code.startIndex, offsetBy: 3),
+                tokenType: .keyword
+            )
+        ])
+        let renderer = CodeBlockRenderer(highlighter: mockHighlighter)
+        let result = renderer.render(
+            CodeBlockRenderer.Input(code: code, language: "swift"),
+            theme: .default,
+            context: RenderContext()
+        )
+
+        // The "let" part should have the keyword color
+        let keywordColor = result.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor
+        let expectedColor = MarkdownTheme.default.syntaxColor(for: "keyword")
+        XCTAssertNotNil(keywordColor)
+        XCTAssertNotNil(expectedColor)
+    }
+
+    func test_codeBlock_withHighlighter_noLanguage_noHighlighting() {
+        let code = "let x = 1"
+        let mockHighlighter = MockSyntaxHighlighter(tokens: [
+            HighlightToken(
+                range: code.startIndex..<code.index(code.startIndex, offsetBy: 3),
+                tokenType: .keyword
+            )
+        ])
+        let renderer = CodeBlockRenderer(highlighter: mockHighlighter)
+        let result = renderer.render(
+            CodeBlockRenderer.Input(code: code, language: nil),
+            theme: .default,
+            context: RenderContext()
+        )
+
+        // Without language, highlighter shouldn't be called
+        XCTAssertFalse(mockHighlighter.highlightCalled)
+        // Should use default text color throughout
+        let color = result.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor
+        XCTAssertNotNil(color)
+    }
+
+    func test_codeBlock_withHighlighter_multipleTokens() {
+        let code = "let x = 1"
+        // "let" is keyword at 0-3, "1" is number at 8-9
+        let mockHighlighter = MockSyntaxHighlighter(tokens: [
+            HighlightToken(
+                range: code.startIndex..<code.index(code.startIndex, offsetBy: 3),
+                tokenType: .keyword
+            ),
+            HighlightToken(
+                range: code.index(code.startIndex, offsetBy: 8)..<code.endIndex,
+                tokenType: .number
+            )
+        ])
+        let renderer = CodeBlockRenderer(highlighter: mockHighlighter)
+        let result = renderer.render(
+            CodeBlockRenderer.Input(code: code, language: "swift"),
+            theme: .default,
+            context: RenderContext()
+        )
+
+        // Verify the code content is preserved
+        XCTAssertTrue(result.string.hasPrefix(code))
+    }
+
+    // MARK: - Paragraph Style Tests
+
+    func test_codeBlock_hasNoParagraphSpacing() {
+        let renderer = CodeBlockRenderer()
+        let result = renderer.render(
+            CodeBlockRenderer.Input(code: "code", language: nil),
+            theme: .default,
+            context: RenderContext()
+        )
+
+        guard let style = result.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle else {
+            XCTFail("Expected paragraph style")
+            return
+        }
+        // Code blocks should preserve lines as-is
+        XCTAssertEqual(style.lineSpacing, 0, accuracy: 0.1)
+    }
+}
+
+// MARK: - Mock Highlighter
+
+private final class MockSyntaxHighlighter: SyntaxHighlighter, @unchecked Sendable {
+    let tokens: [HighlightToken]
+    private(set) var highlightCalled = false
+
+    init(tokens: [HighlightToken]) {
+        self.tokens = tokens
+    }
+
+    var supportedLanguages: [String] {
+        ["swift", "javascript", "python"]
+    }
+
+    func supportsLanguage(_ language: String) -> Bool {
+        supportedLanguages.contains(language.lowercased())
+    }
+
+    func highlight(code: String, language: String) -> [HighlightToken] {
+        highlightCalled = true
+        return tokens
+    }
+}


### PR DESCRIPTION
## Summary
- Add `CodeBlockRenderer` for rendering fenced code blocks to NSAttributedString
- Renders with monospace font and background color from theme
- Integrates with existing `SyntaxHighlighter` protocol for syntax coloring
- Converts `HighlightToken` ranges to `.foregroundColor` attributes
- Preserves whitespace and adds trailing newline for block separation

## Architecture
Reuses existing Tree-sitter infrastructure unchanged:
- Same dylibs and `GrammarManager`
- Same `SyntaxHighlighter` protocol and `HighlightToken` type
- Only the output transformation changes (HTML spans → attributed string ranges)

## Test plan
- [x] 12 new tests pass covering:
  - Monospace font and font size
  - Background color
  - Whitespace preservation
  - Syntax highlighting with mock highlighter
  - No highlighting when language is nil
- [x] SwiftLint passes in strict mode
- [x] Build succeeds

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)