### PR TITLE
feat: add BlockquoteRenderer and HorizontalRuleRenderer

### DIFF
--- a/SwiftMarkdown.xcodeproj/project.pbxproj
+++ b/SwiftMarkdown.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		497FDC1338C5EF65407603A9 /* PlainTextRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6EA9AC7D0321DC237CAA56 /* PlainTextRendererTests.swift */; };
 		4AD0857EDCD7170E75955150 /* HTMLRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C92EEC01DFECF39F9FD67D25 /* HTMLRenderer.swift */; };
 		4B765172AAD959C57FFDCB93 /* ImageValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60124B861E67B3E2919B216 /* ImageValidatorTests.swift */; };
+		5285AB1B147EC42BC092F25C /* HorizontalRuleAttachmentCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFAFFD7680E6AB06A9089D52 /* HorizontalRuleAttachmentCell.swift */; };
 		54F77ED86A73956332B1BD16 /* ImageValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E01F16278E86C893DE1324F /* ImageValidator.swift */; };
 		56D9CF15EB83D8C20BC0A36E /* CodeBlockRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A622678EECA60D591402AC63 /* CodeBlockRendererTests.swift */; };
 		5A3162197FD39082852C1554 /* GrammarManifestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8241641705639E7415FA4283 /* GrammarManifestTests.swift */; };
@@ -46,12 +47,14 @@
 		8C3CC2C3BD9A2E3829924968 /* LanguagesSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A0A9589AEE5642AA8EDD742 /* LanguagesSettingsView.swift */; };
 		8EC47975A4146FA9820BE9C6 /* GrammarManifest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCAAFBA7E1B67A000AC2B618 /* GrammarManifest.swift */; };
 		8F28F142CAC5252C0731CA00 /* ParagraphRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB5CD8FE780796690BC1B270 /* ParagraphRendererTests.swift */; };
+		90862EB3FB5D9F6BD580CB77 /* HorizontalRuleRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D53ABA83139D6B75A5FDF1B7 /* HorizontalRuleRenderer.swift */; };
 		91AE9B4B84FEDF679211AC2C /* GrammarManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD3CDE3FFECEED6781027B84 /* GrammarManager.swift */; };
 		995579FCC7904D20D478CAFE /* DocumentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBDAD7D77917A5FE54AA5EEC /* DocumentViewModel.swift */; };
 		9BC7D5E80962F3FB38E4A7FB /* MarkdownParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = DACBD54BE4C8A5E5D4E205F0 /* MarkdownParser.swift */; };
 		9C2B9CA834D9FBFA2B467B8C /* SyntaxHighlighterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5D9247F726F851B63E511B7 /* SyntaxHighlighterTests.swift */; };
 		9CA4F91A86112062D1F0CE34 /* EmphasisRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D05EB02BCC6049F8103278 /* EmphasisRendererTests.swift */; };
 		A02C25D7D5EB7A7FA04FA3A2 /* SwiftMarkdownCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 95F447A42C55828BB50C30B5 /* SwiftMarkdownCore.framework */; };
+		A778D929B9415B9205C3DB7D /* HorizontalRuleRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F09FE7F417D7D382050EFEB /* HorizontalRuleRendererTests.swift */; };
 		AF8F0684CF16EC5EF970B62D /* DropCapturingWebViewContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3401AC69BB54A1B91FB67575 /* DropCapturingWebViewContainer.swift */; };
 		B3511C3EBFB926B7CC8C938E /* StrikethroughRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00544E1DFD470B5355389E3B /* StrikethroughRendererTests.swift */; };
 		B62DA1212D7023532FE54785 /* MarkdownFileValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE00EC83B9FE79ABD2F975B2 /* MarkdownFileValidator.swift */; };
@@ -66,6 +69,7 @@
 		C32DCDDECDFF9724F53C0D2C /* EmphasisRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7954C82A1FB5381C3ABE0707 /* EmphasisRenderer.swift */; };
 		C3B167FD38C733B112E277FF /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BB6B52D45ED0A11407D90A /* ContentView.swift */; };
 		C4F792554A8EB669109AD412 /* MarkdownParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89DC4E84AA6CB7A55815B7F /* MarkdownParserTests.swift */; };
+		C8D6F02A3351E4E830D4FFD8 /* BlockquoteRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0920FB855ABA9CC68A905F87 /* BlockquoteRendererTests.swift */; };
 		CBEBB2FA9092AD797D0FF830 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1D5E5838A8AEC4E0FDC523A2 /* Assets.xcassets */; };
 		CE41789129144C3BD9A4413F /* GrammarLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7F436562B096EB84F996FEC /* GrammarLoader.swift */; };
 		D35E9EA520E2F843B036FE55 /* SwiftMarkdownCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 95F447A42C55828BB50C30B5 /* SwiftMarkdownCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -74,6 +78,7 @@
 		E7DC039E672A8522E18C7785 /* MarkdownElementRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C813CBA11576B44D762E7DB /* MarkdownElementRenderer.swift */; };
 		EA230962EBA9CC4D80D931C7 /* HeadingRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EFEC18875BBF78E7B47009 /* HeadingRendererTests.swift */; };
 		EB764BC34358D77079283071 /* SettingsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CC9349E626F73A9860EEAF9 /* SettingsManager.swift */; };
+		EC8570B8D884B57D91898634 /* BlockquoteRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B33EE552191E266ACEBB67F3 /* BlockquoteRenderer.swift */; };
 		EDB84B1B268301165FBDCB45 /* HTMLRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0732F7FFFF2CB2CA3AAF34 /* HTMLRendererTests.swift */; };
 		F3620E5B6496C3C6425AB0D6 /* Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 308323B184C4405BE95A6BC0 /* Settings.swift */; };
 		F3C0DBD72E43F100AE91CECE /* SyntaxHighlighter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0870ADD570D5EF2C00DA1C40 /* SyntaxHighlighter.swift */; };
@@ -160,6 +165,7 @@
 		01D864EB38F9DA2270E06F31 /* SyntaxTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyntaxTheme.swift; sourceTree = "<group>"; };
 		02670C70052A0BFF18A3A2CF /* SettingsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsManagerTests.swift; sourceTree = "<group>"; };
 		0870ADD570D5EF2C00DA1C40 /* SyntaxHighlighter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyntaxHighlighter.swift; sourceTree = "<group>"; };
+		0920FB855ABA9CC68A905F87 /* BlockquoteRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockquoteRendererTests.swift; sourceTree = "<group>"; };
 		09AA4F3A79326A0FCC93CA54 /* PlainTextRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlainTextRenderer.swift; sourceTree = "<group>"; };
 		0A0A9589AEE5642AA8EDD742 /* LanguagesSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguagesSettingsView.swift; sourceTree = "<group>"; };
 		0C813CBA11576B44D762E7DB /* MarkdownElementRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownElementRenderer.swift; sourceTree = "<group>"; };
@@ -195,13 +201,16 @@
 		8CC5212680E478B3FD2CFF8B /* InlineCodeRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineCodeRendererTests.swift; sourceTree = "<group>"; };
 		95F447A42C55828BB50C30B5 /* SwiftMarkdownCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftMarkdownCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9B786F7F67635FFA4DB2D52B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		9F09FE7F417D7D382050EFEB /* HorizontalRuleRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HorizontalRuleRendererTests.swift; sourceTree = "<group>"; };
 		A1A8BA27FF96144B1141281F /* MarkdownTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownTheme.swift; sourceTree = "<group>"; };
 		A622678EECA60D591402AC63 /* CodeBlockRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeBlockRendererTests.swift; sourceTree = "<group>"; };
 		AAD5D435CF1AD986041106BF /* HeadingRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeadingRenderer.swift; sourceTree = "<group>"; };
 		AB5CD8FE780796690BC1B270 /* ParagraphRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParagraphRendererTests.swift; sourceTree = "<group>"; };
 		AE6EA9AC7D0321DC237CAA56 /* PlainTextRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlainTextRendererTests.swift; sourceTree = "<group>"; };
+		B33EE552191E266ACEBB67F3 /* BlockquoteRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockquoteRenderer.swift; sourceTree = "<group>"; };
 		B5BB6B52D45ED0A11407D90A /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		BCAAFBA7E1B67A000AC2B618 /* GrammarManifest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrammarManifest.swift; sourceTree = "<group>"; };
+		BFAFFD7680E6AB06A9089D52 /* HorizontalRuleAttachmentCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HorizontalRuleAttachmentCell.swift; sourceTree = "<group>"; };
 		C5D9247F726F851B63E511B7 /* SyntaxHighlighterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyntaxHighlighterTests.swift; sourceTree = "<group>"; };
 		C6BA59B73EF3AAC7F3AF2274 /* StringHTMLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringHTMLTests.swift; sourceTree = "<group>"; };
 		C71DB50CDF53477DC2D121D2 /* LinkRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkRenderer.swift; sourceTree = "<group>"; };
@@ -210,6 +219,7 @@
 		CC3C7E294336DAA8FA4C403E /* MarkdownRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownRenderer.swift; sourceTree = "<group>"; };
 		CD3CDE3FFECEED6781027B84 /* GrammarManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrammarManager.swift; sourceTree = "<group>"; };
 		CEC8CA1672656602F42D2D15 /* MarkdownWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownWebView.swift; sourceTree = "<group>"; };
+		D53ABA83139D6B75A5FDF1B7 /* HorizontalRuleRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HorizontalRuleRenderer.swift; sourceTree = "<group>"; };
 		D59B743B5EFB7435B9954AAA /* SwiftMarkdownCoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftMarkdownCoreTests.swift; sourceTree = "<group>"; };
 		D89DC4E84AA6CB7A55815B7F /* MarkdownParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownParserTests.swift; sourceTree = "<group>"; };
 		DACBD54BE4C8A5E5D4E205F0 /* MarkdownParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownParser.swift; sourceTree = "<group>"; };
@@ -300,9 +310,12 @@
 		65FBBEE2C660B7670670C8FD /* NativeRendering */ = {
 			isa = PBXGroup;
 			children = (
+				B33EE552191E266ACEBB67F3 /* BlockquoteRenderer.swift */,
 				612239001FD5DED5060CBE48 /* CodeBlockRenderer.swift */,
 				7954C82A1FB5381C3ABE0707 /* EmphasisRenderer.swift */,
 				AAD5D435CF1AD986041106BF /* HeadingRenderer.swift */,
+				BFAFFD7680E6AB06A9089D52 /* HorizontalRuleAttachmentCell.swift */,
+				D53ABA83139D6B75A5FDF1B7 /* HorizontalRuleRenderer.swift */,
 				7130A40117A04774C2B20CA6 /* InlineCodeRenderer.swift */,
 				C71DB50CDF53477DC2D121D2 /* LinkRenderer.swift */,
 				0C813CBA11576B44D762E7DB /* MarkdownElementRenderer.swift */,
@@ -423,11 +436,13 @@
 		EE46B3B0894560244A3035ED /* SwiftMarkdownTests */ = {
 			isa = PBXGroup;
 			children = (
+				0920FB855ABA9CC68A905F87 /* BlockquoteRendererTests.swift */,
 				A622678EECA60D591402AC63 /* CodeBlockRendererTests.swift */,
 				F4D05EB02BCC6049F8103278 /* EmphasisRendererTests.swift */,
 				7B063556DF68B1428DE338C6 /* GrammarManagerTests.swift */,
 				8241641705639E7415FA4283 /* GrammarManifestTests.swift */,
 				80EFEC18875BBF78E7B47009 /* HeadingRendererTests.swift */,
+				9F09FE7F417D7D382050EFEB /* HorizontalRuleRendererTests.swift */,
 				CC0732F7FFFF2CB2CA3AAF34 /* HTMLRendererTests.swift */,
 				F60124B861E67B3E2919B216 /* ImageValidatorTests.swift */,
 				9B786F7F67635FFA4DB2D52B /* Info.plist */,
@@ -620,12 +635,14 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C8D6F02A3351E4E830D4FFD8 /* BlockquoteRendererTests.swift in Sources */,
 				56D9CF15EB83D8C20BC0A36E /* CodeBlockRendererTests.swift in Sources */,
 				9CA4F91A86112062D1F0CE34 /* EmphasisRendererTests.swift in Sources */,
 				1D4D4F6C986946DEFDBEE790 /* GrammarManagerTests.swift in Sources */,
 				5A3162197FD39082852C1554 /* GrammarManifestTests.swift in Sources */,
 				EDB84B1B268301165FBDCB45 /* HTMLRendererTests.swift in Sources */,
 				EA230962EBA9CC4D80D931C7 /* HeadingRendererTests.swift in Sources */,
+				A778D929B9415B9205C3DB7D /* HorizontalRuleRendererTests.swift in Sources */,
 				4B765172AAD959C57FFDCB93 /* ImageValidatorTests.swift in Sources */,
 				7BD7CFD302515677C6911CDF /* InlineCodeRendererTests.swift in Sources */,
 				3D50457A90E8257576B1DCF9 /* LinkRendererTests.swift in Sources */,
@@ -649,6 +666,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BFA78EFE0811FC9BB1CCA532 /* AsyncHTMLWalker.swift in Sources */,
+				EC8570B8D884B57D91898634 /* BlockquoteRenderer.swift in Sources */,
 				0009EB03C15B74FED0F85D93 /* CodeBlockRenderer.swift in Sources */,
 				C32DCDDECDFF9724F53C0D2C /* EmphasisRenderer.swift in Sources */,
 				36BD2E50E187FB530399C70F /* FileSystemProtocol.swift in Sources */,
@@ -659,6 +677,8 @@
 				2A2BE085D8889759487C9567 /* HTMLElementRenderer.swift in Sources */,
 				4AD0857EDCD7170E75955150 /* HTMLRenderer.swift in Sources */,
 				BA340EFAC205E3C8B13F4703 /* HeadingRenderer.swift in Sources */,
+				5285AB1B147EC42BC092F25C /* HorizontalRuleAttachmentCell.swift in Sources */,
+				90862EB3FB5D9F6BD580CB77 /* HorizontalRuleRenderer.swift in Sources */,
 				54F77ED86A73956332B1BD16 /* ImageValidator.swift in Sources */,
 				6E42234A0F6832CAF8D21F35 /* InlineCodeRenderer.swift in Sources */,
 				64165C72A942F3412114805D /* LazyTreeSitterHighlighter.swift in Sources */,

--- a/SwiftMarkdownCore/NativeRendering/BlockquoteRenderer.swift
+++ b/SwiftMarkdownCore/NativeRendering/BlockquoteRenderer.swift
@@ -1,0 +1,49 @@
+import AppKit
+
+/// Renders markdown blockquotes to NSAttributedString with indentation and styling.
+///
+/// Blockquotes use the theme's blockquote color and indentation. Nesting is supported
+/// via the render context's nesting level, which increases the indentation.
+///
+/// ## Example
+/// ```swift
+/// let renderer = BlockquoteRenderer()
+/// let content = NSAttributedString(string: "A famous quote")
+/// let result = renderer.render(
+///     content,
+///     theme: .default,
+///     context: RenderContext()
+/// )
+/// ```
+public struct BlockquoteRenderer: MarkdownElementRenderer {
+    public typealias Input = NSAttributedString
+
+    public init() {}
+
+    public func render(_ input: NSAttributedString, theme: MarkdownTheme, context: RenderContext) -> NSAttributedString {
+        // Calculate indent based on nesting level (1x for level 0, 2x for level 1, etc.)
+        let indentMultiplier = CGFloat(context.nestingLevel + 1)
+        let indent = theme.blockquoteIndent * indentMultiplier
+
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.headIndent = indent
+        paragraphStyle.firstLineHeadIndent = indent
+        paragraphStyle.paragraphSpacing = theme.paragraphSpacing
+
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: theme.bodyFont,
+            .foregroundColor: theme.blockquoteColor,
+            .paragraphStyle: paragraphStyle
+        ]
+
+        // Create new attributed string with blockquote styling
+        let result = NSMutableAttributedString(string: input.string, attributes: attributes)
+
+        // Ensure trailing newline for block separation
+        if !result.string.hasSuffix("\n") {
+            result.append(NSAttributedString(string: "\n", attributes: attributes))
+        }
+
+        return result
+    }
+}

--- a/SwiftMarkdownCore/NativeRendering/HorizontalRuleAttachmentCell.swift
+++ b/SwiftMarkdownCore/NativeRendering/HorizontalRuleAttachmentCell.swift
@@ -1,0 +1,62 @@
+import AppKit
+
+/// A text attachment cell that draws a horizontal rule line.
+///
+/// This cell renders a thin horizontal line that spans most of its width,
+/// used for markdown horizontal rules (---).
+final class HorizontalRuleAttachmentCell: NSTextAttachmentCell {
+    private let lineColor: NSColor
+    private let lineThickness: CGFloat
+
+    /// Creates a horizontal rule attachment cell.
+    ///
+    /// - Parameters:
+    ///   - color: The color of the line.
+    ///   - thickness: The thickness of the line in points.
+    init(color: NSColor, thickness: CGFloat = 1.0) {
+        self.lineColor = color
+        self.lineThickness = thickness
+        super.init()
+    }
+
+    @available(*, unavailable)
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func cellSize() -> NSSize {
+        // Height includes some padding around the line
+        NSSize(width: 100, height: 16)
+    }
+
+    override func cellBaselineOffset() -> NSPoint {
+        NSPoint(x: 0, y: -4)
+    }
+
+    override func draw(withFrame cellFrame: NSRect, in controlView: NSView?) {
+        lineColor.setFill()
+
+        // Draw a horizontal line centered vertically in the cell
+        let lineY = cellFrame.midY - lineThickness / 2
+        let lineRect = NSRect(
+            x: cellFrame.minX,
+            y: lineY,
+            width: cellFrame.width,
+            height: lineThickness
+        )
+        lineRect.fill()
+    }
+
+    override func draw(withFrame cellFrame: NSRect, in controlView: NSView?, characterIndex charIndex: Int) {
+        draw(withFrame: cellFrame, in: controlView)
+    }
+
+    override func draw(
+        withFrame cellFrame: NSRect,
+        in controlView: NSView?,
+        characterIndex charIndex: Int,
+        layoutManager: NSLayoutManager
+    ) {
+        draw(withFrame: cellFrame, in: controlView)
+    }
+}

--- a/SwiftMarkdownCore/NativeRendering/HorizontalRuleRenderer.swift
+++ b/SwiftMarkdownCore/NativeRendering/HorizontalRuleRenderer.swift
@@ -1,0 +1,45 @@
+import AppKit
+
+/// Renders markdown horizontal rules (---) to NSAttributedString with a visual line.
+///
+/// Uses an NSTextAttachment with a custom cell to draw the horizontal line.
+/// The line is surrounded by newlines for visual separation.
+///
+/// ## Example
+/// ```swift
+/// let renderer = HorizontalRuleRenderer()
+/// let result = renderer.render(
+///     (),
+///     theme: .default,
+///     context: RenderContext()
+/// )
+/// ```
+public struct HorizontalRuleRenderer: MarkdownElementRenderer {
+    public typealias Input = Void
+
+    public init() {}
+
+    public func render(_ input: Void, theme: MarkdownTheme, context: RenderContext) -> NSAttributedString {
+        let result = NSMutableAttributedString()
+
+        // Add leading newline for spacing
+        result.append(NSAttributedString(string: "\n"))
+
+        // Create the horizontal rule attachment
+        let attachment = NSTextAttachment()
+        let cell = HorizontalRuleAttachmentCell(color: theme.textColor)
+        attachment.attachmentCell = cell
+
+        // Set bounds for the attachment (width will be overridden by text container)
+        attachment.bounds = NSRect(x: 0, y: 0, width: 100, height: 16)
+
+        // Create the attachment string
+        let attachmentString = NSAttributedString(attachment: attachment)
+        result.append(attachmentString)
+
+        // Add trailing newline for spacing
+        result.append(NSAttributedString(string: "\n"))
+
+        return result
+    }
+}

--- a/SwiftMarkdownTests/BlockquoteRendererTests.swift
+++ b/SwiftMarkdownTests/BlockquoteRendererTests.swift
@@ -1,0 +1,151 @@
+import XCTest
+@testable import SwiftMarkdownCore
+
+final class BlockquoteRendererTests: XCTestCase {
+    // MARK: - Indentation Tests
+
+    func test_blockquote_hasLeftIndent() {
+        let renderer = BlockquoteRenderer()
+        let content = NSAttributedString(string: "quoted text")
+        let result = renderer.render(
+            content,
+            theme: .default,
+            context: RenderContext()
+        )
+
+        guard let style = result.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle else {
+            XCTFail("Expected paragraph style")
+            return
+        }
+        XCTAssertGreaterThan(style.headIndent, 0)
+    }
+
+    func test_blockquote_hasFirstLineIndent() {
+        let renderer = BlockquoteRenderer()
+        let content = NSAttributedString(string: "quoted text")
+        let result = renderer.render(
+            content,
+            theme: .default,
+            context: RenderContext()
+        )
+
+        guard let style = result.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle else {
+            XCTFail("Expected paragraph style")
+            return
+        }
+        XCTAssertGreaterThan(style.firstLineHeadIndent, 0)
+    }
+
+    func test_blockquote_usesThemeBlockquoteIndent() {
+        let renderer = BlockquoteRenderer()
+        let content = NSAttributedString(string: "quoted")
+        let result = renderer.render(
+            content,
+            theme: .default,
+            context: RenderContext()
+        )
+
+        guard let style = result.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle else {
+            XCTFail("Expected paragraph style")
+            return
+        }
+        XCTAssertEqual(style.headIndent, MarkdownTheme.default.blockquoteIndent, accuracy: 0.1)
+    }
+
+    // MARK: - Nesting Tests
+
+    func test_blockquote_nested_increasesIndent() {
+        let renderer = BlockquoteRenderer()
+        let content = NSAttributedString(string: "nested")
+        let context = RenderContext(nestingLevel: 1)
+        let result = renderer.render(
+            content,
+            theme: .default,
+            context: context
+        )
+
+        guard let style = result.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle else {
+            XCTFail("Expected paragraph style")
+            return
+        }
+        // Nested indent should be greater than single indent
+        XCTAssertGreaterThan(style.headIndent, MarkdownTheme.default.blockquoteIndent)
+    }
+
+    func test_blockquote_deeplyNested_scaledIndent() {
+        let renderer = BlockquoteRenderer()
+        let content = NSAttributedString(string: "deeply nested")
+        let context = RenderContext(nestingLevel: 2)
+        let result = renderer.render(
+            content,
+            theme: .default,
+            context: context
+        )
+
+        guard let style = result.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle else {
+            XCTFail("Expected paragraph style")
+            return
+        }
+        let expectedIndent = MarkdownTheme.default.blockquoteIndent * 3 // level 2 = 3x indent
+        XCTAssertEqual(style.headIndent, expectedIndent, accuracy: 0.1)
+    }
+
+    // MARK: - Color Tests
+
+    func test_blockquote_usesBlockquoteColor() {
+        let renderer = BlockquoteRenderer()
+        let content = NSAttributedString(string: "quoted")
+        let result = renderer.render(
+            content,
+            theme: .default,
+            context: RenderContext()
+        )
+
+        let color = result.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor
+        XCTAssertNotNil(color)
+    }
+
+    // MARK: - Content Tests
+
+    func test_blockquote_preservesContent() {
+        let renderer = BlockquoteRenderer()
+        let content = NSAttributedString(string: "my quote text")
+        let result = renderer.render(
+            content,
+            theme: .default,
+            context: RenderContext()
+        )
+
+        XCTAssertTrue(result.string.contains("my quote text"))
+    }
+
+    func test_blockquote_addsTrailingNewline() {
+        let renderer = BlockquoteRenderer()
+        let content = NSAttributedString(string: "quote")
+        let result = renderer.render(
+            content,
+            theme: .default,
+            context: RenderContext()
+        )
+
+        XCTAssertTrue(result.string.hasSuffix("\n"))
+    }
+
+    // MARK: - Font Tests
+
+    func test_blockquote_usesBodyFont() {
+        let renderer = BlockquoteRenderer()
+        let content = NSAttributedString(string: "quote")
+        let result = renderer.render(
+            content,
+            theme: .default,
+            context: RenderContext()
+        )
+
+        guard let font = result.attribute(.font, at: 0, effectiveRange: nil) as? NSFont else {
+            XCTFail("Expected font attribute")
+            return
+        }
+        XCTAssertEqual(font.pointSize, MarkdownTheme.default.bodyFontSize, accuracy: 0.1)
+    }
+}

--- a/SwiftMarkdownTests/HorizontalRuleRendererTests.swift
+++ b/SwiftMarkdownTests/HorizontalRuleRendererTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+@testable import SwiftMarkdownCore
+
+final class HorizontalRuleRendererTests: XCTestCase {
+    // MARK: - Attachment Tests
+
+    func test_horizontalRule_createsAttachment() {
+        let renderer = HorizontalRuleRenderer()
+        let result = renderer.render(
+            (),
+            theme: .default,
+            context: RenderContext()
+        )
+
+        // Attachment is at position 1 (after leading newline)
+        let attachment = result.attribute(.attachment, at: 1, effectiveRange: nil)
+        XCTAssertNotNil(attachment)
+    }
+
+    func test_horizontalRule_containsAttachmentCharacter() {
+        let renderer = HorizontalRuleRenderer()
+        let result = renderer.render(
+            (),
+            theme: .default,
+            context: RenderContext()
+        )
+
+        // NSTextAttachment uses the object replacement character
+        XCTAssertTrue(result.string.contains("\u{FFFC}"))
+    }
+
+    // MARK: - Spacing Tests
+
+    func test_horizontalRule_addsTrailingNewline() {
+        let renderer = HorizontalRuleRenderer()
+        let result = renderer.render(
+            (),
+            theme: .default,
+            context: RenderContext()
+        )
+
+        XCTAssertTrue(result.string.hasSuffix("\n"))
+    }
+
+    func test_horizontalRule_hasLeadingNewline() {
+        let renderer = HorizontalRuleRenderer()
+        let result = renderer.render(
+            (),
+            theme: .default,
+            context: RenderContext()
+        )
+
+        XCTAssertTrue(result.string.hasPrefix("\n"))
+    }
+
+    // MARK: - Size Tests
+
+    func test_horizontalRule_attachmentHasSize() {
+        let renderer = HorizontalRuleRenderer()
+        let result = renderer.render(
+            (),
+            theme: .default,
+            context: RenderContext()
+        )
+
+        guard let attachment = result.attribute(.attachment, at: 1, effectiveRange: nil) as? NSTextAttachment else {
+            XCTFail("Expected text attachment")
+            return
+        }
+        // Attachment should have non-zero bounds
+        XCTAssertGreaterThan(attachment.bounds.height, 0)
+    }
+}


### PR DESCRIPTION
## Summary
Add two block-level renderers for native NSAttributedString rendering:

**BlockquoteRenderer:**
- Uses `NSParagraphStyle` with `headIndent` and `firstLineHeadIndent`
- Applies theme's `blockquoteColor` for subdued quote text
- Supports nesting via `context.nestingLevel` (multiplies indentation)

**HorizontalRuleRenderer:**
- Uses `NSTextAttachment` with custom `HorizontalRuleAttachmentCell`
- Cell draws a horizontal line spanning its width
- Surrounded by newlines for visual spacing

## Test plan
- [x] 9 BlockquoteRenderer tests pass (indentation, nesting, color, font)
- [x] 5 HorizontalRuleRenderer tests pass (attachment, spacing, size)
- [x] SwiftLint passes in strict mode
- [x] Build succeeds

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)