### PR TITLE
feat: add ImageRenderer for inline images

### DIFF
--- a/SwiftMarkdown.xcodeproj/project.pbxproj
+++ b/SwiftMarkdown.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		A778D929B9415B9205C3DB7D /* HorizontalRuleRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F09FE7F417D7D382050EFEB /* HorizontalRuleRendererTests.swift */; };
 		AF8F0684CF16EC5EF970B62D /* DropCapturingWebViewContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3401AC69BB54A1B91FB67575 /* DropCapturingWebViewContainer.swift */; };
 		B3511C3EBFB926B7CC8C938E /* StrikethroughRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00544E1DFD470B5355389E3B /* StrikethroughRendererTests.swift */; };
+		B4E1FA8F82F4C8C3B5B1EB80 /* ImageRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D127DED15B2FE46AEBFA468 /* ImageRenderer.swift */; };
 		B62DA1212D7023532FE54785 /* MarkdownFileValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE00EC83B9FE79ABD2F975B2 /* MarkdownFileValidator.swift */; };
 		B6BAEE9D266B0B4E25F36503 /* SyntaxThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A5BCE3B3DF1F9E273618397 /* SyntaxThemeTests.swift */; };
 		B92C700D2386D46D2189E346 /* StringHTMLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6BA59B73EF3AAC7F3AF2274 /* StringHTMLTests.swift */; };
@@ -83,6 +84,7 @@
 		EB764BC34358D77079283071 /* SettingsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CC9349E626F73A9860EEAF9 /* SettingsManager.swift */; };
 		EC8570B8D884B57D91898634 /* BlockquoteRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B33EE552191E266ACEBB67F3 /* BlockquoteRenderer.swift */; };
 		EDB84B1B268301165FBDCB45 /* HTMLRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0732F7FFFF2CB2CA3AAF34 /* HTMLRendererTests.swift */; };
+		F2D5D29D2287586F5BB7BD84 /* ImageRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C34B61E7B48E091342EB990F /* ImageRendererTests.swift */; };
 		F3620E5B6496C3C6425AB0D6 /* Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 308323B184C4405BE95A6BC0 /* Settings.swift */; };
 		F3C0DBD72E43F100AE91CECE /* SyntaxHighlighter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0870ADD570D5EF2C00DA1C40 /* SyntaxHighlighter.swift */; };
 		F6E7533793D2B14E0BD4DF7F /* PlainTextRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09AA4F3A79326A0FCC93CA54 /* PlainTextRenderer.swift */; };
@@ -172,6 +174,7 @@
 		09AA4F3A79326A0FCC93CA54 /* PlainTextRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlainTextRenderer.swift; sourceTree = "<group>"; };
 		0A0A9589AEE5642AA8EDD742 /* LanguagesSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguagesSettingsView.swift; sourceTree = "<group>"; };
 		0C813CBA11576B44D762E7DB /* MarkdownElementRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownElementRenderer.swift; sourceTree = "<group>"; };
+		0D127DED15B2FE46AEBFA468 /* ImageRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRenderer.swift; sourceTree = "<group>"; };
 		0FCA2AD44D0DD56826C82B4B /* ListRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListRenderer.swift; sourceTree = "<group>"; };
 		1950124C4309C0ACB7236CF3 /* LinkRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkRendererTests.swift; sourceTree = "<group>"; };
 		1D5E5838A8AEC4E0FDC523A2 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -217,6 +220,7 @@
 		B5BB6B52D45ED0A11407D90A /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		BCAAFBA7E1B67A000AC2B618 /* GrammarManifest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrammarManifest.swift; sourceTree = "<group>"; };
 		BFAFFD7680E6AB06A9089D52 /* HorizontalRuleAttachmentCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HorizontalRuleAttachmentCell.swift; sourceTree = "<group>"; };
+		C34B61E7B48E091342EB990F /* ImageRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRendererTests.swift; sourceTree = "<group>"; };
 		C5D9247F726F851B63E511B7 /* SyntaxHighlighterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyntaxHighlighterTests.swift; sourceTree = "<group>"; };
 		C6BA59B73EF3AAC7F3AF2274 /* StringHTMLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringHTMLTests.swift; sourceTree = "<group>"; };
 		C71DB50CDF53477DC2D121D2 /* LinkRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkRenderer.swift; sourceTree = "<group>"; };
@@ -322,6 +326,7 @@
 				AAD5D435CF1AD986041106BF /* HeadingRenderer.swift */,
 				BFAFFD7680E6AB06A9089D52 /* HorizontalRuleAttachmentCell.swift */,
 				D53ABA83139D6B75A5FDF1B7 /* HorizontalRuleRenderer.swift */,
+				0D127DED15B2FE46AEBFA468 /* ImageRenderer.swift */,
 				7130A40117A04774C2B20CA6 /* InlineCodeRenderer.swift */,
 				C71DB50CDF53477DC2D121D2 /* LinkRenderer.swift */,
 				0FCA2AD44D0DD56826C82B4B /* ListRenderer.swift */,
@@ -452,6 +457,7 @@
 				80EFEC18875BBF78E7B47009 /* HeadingRendererTests.swift */,
 				9F09FE7F417D7D382050EFEB /* HorizontalRuleRendererTests.swift */,
 				CC0732F7FFFF2CB2CA3AAF34 /* HTMLRendererTests.swift */,
+				C34B61E7B48E091342EB990F /* ImageRendererTests.swift */,
 				F60124B861E67B3E2919B216 /* ImageValidatorTests.swift */,
 				9B786F7F67635FFA4DB2D52B /* Info.plist */,
 				8CC5212680E478B3FD2CFF8B /* InlineCodeRendererTests.swift */,
@@ -652,6 +658,7 @@
 				EDB84B1B268301165FBDCB45 /* HTMLRendererTests.swift in Sources */,
 				EA230962EBA9CC4D80D931C7 /* HeadingRendererTests.swift in Sources */,
 				A778D929B9415B9205C3DB7D /* HorizontalRuleRendererTests.swift in Sources */,
+				F2D5D29D2287586F5BB7BD84 /* ImageRendererTests.swift in Sources */,
 				4B765172AAD959C57FFDCB93 /* ImageValidatorTests.swift in Sources */,
 				7BD7CFD302515677C6911CDF /* InlineCodeRendererTests.swift in Sources */,
 				3D50457A90E8257576B1DCF9 /* LinkRendererTests.swift in Sources */,
@@ -689,6 +696,7 @@
 				BA340EFAC205E3C8B13F4703 /* HeadingRenderer.swift in Sources */,
 				5285AB1B147EC42BC092F25C /* HorizontalRuleAttachmentCell.swift in Sources */,
 				90862EB3FB5D9F6BD580CB77 /* HorizontalRuleRenderer.swift in Sources */,
+				B4E1FA8F82F4C8C3B5B1EB80 /* ImageRenderer.swift in Sources */,
 				54F77ED86A73956332B1BD16 /* ImageValidator.swift in Sources */,
 				6E42234A0F6832CAF8D21F35 /* InlineCodeRenderer.swift in Sources */,
 				64165C72A942F3412114805D /* LazyTreeSitterHighlighter.swift in Sources */,

--- a/SwiftMarkdownCore/NativeRendering/ImageRenderer.swift
+++ b/SwiftMarkdownCore/NativeRendering/ImageRenderer.swift
@@ -1,0 +1,93 @@
+import AppKit
+
+/// Renders markdown images to NSAttributedString with NSTextAttachment.
+///
+/// Images are displayed inline using text attachments. Size is constrained
+/// to a maximum width while maintaining aspect ratio. Accessibility
+/// descriptions are set from alt text.
+///
+/// ## Example
+/// ```swift
+/// let renderer = ImageRenderer(maxWidth: 600)
+/// let image = NSImage(contentsOf: imageURL)
+/// let result = renderer.render(
+///     ImageRenderer.Input(image: image, altText: "Photo of sunset"),
+///     theme: .default,
+///     context: RenderContext()
+/// )
+/// ```
+public struct ImageRenderer: MarkdownElementRenderer {
+    /// Input for image rendering.
+    public struct Input {
+        /// The image to render (nil for placeholder).
+        public let image: NSImage?
+        /// Alt text for accessibility.
+        public let altText: String
+
+        public init(image: NSImage?, altText: String) {
+            self.image = image
+            self.altText = altText
+        }
+    }
+
+    /// Maximum width for images.
+    private let maxWidth: CGFloat
+
+    /// Creates an image renderer.
+    ///
+    /// - Parameter maxWidth: Maximum width for displayed images. Images wider than
+    ///   this will be scaled down while maintaining aspect ratio.
+    public init(maxWidth: CGFloat = 800) {
+        self.maxWidth = maxWidth
+    }
+
+    public func render(_ input: Input, theme: MarkdownTheme, context: RenderContext) -> NSAttributedString {
+        let result = NSMutableAttributedString()
+
+        if let image = input.image {
+            // Set accessibility description
+            if !input.altText.isEmpty {
+                image.accessibilityDescription = input.altText
+            }
+
+            // Calculate constrained size
+            let constrainedSize = calculateConstrainedSize(for: image)
+
+            // Create attachment
+            let attachment = NSTextAttachment()
+            attachment.image = image
+            attachment.bounds = NSRect(origin: .zero, size: constrainedSize)
+
+            result.append(NSAttributedString(attachment: attachment))
+        } else {
+            // Placeholder for missing image
+            let placeholder = "[\(input.altText.isEmpty ? "Image" : input.altText)]"
+            let attributes: [NSAttributedString.Key: Any] = [
+                .font: theme.bodyFont,
+                .foregroundColor: NSColor.secondaryLabelColor
+            ]
+            result.append(NSAttributedString(string: placeholder, attributes: attributes))
+        }
+
+        // Add trailing newline for block separation
+        result.append(NSAttributedString(string: "\n"))
+
+        return result
+    }
+
+    private func calculateConstrainedSize(for image: NSImage) -> NSSize {
+        let originalSize = image.size
+
+        // If image is smaller than max width, keep original size
+        guard originalSize.width > maxWidth else {
+            return originalSize
+        }
+
+        // Scale down while maintaining aspect ratio
+        let scale = maxWidth / originalSize.width
+        return NSSize(
+            width: maxWidth,
+            height: originalSize.height * scale
+        )
+    }
+}

--- a/SwiftMarkdownTests/ImageRendererTests.swift
+++ b/SwiftMarkdownTests/ImageRendererTests.swift
@@ -1,0 +1,162 @@
+import XCTest
+@testable import SwiftMarkdownCore
+
+final class ImageRendererTests: XCTestCase {
+    // MARK: - Test Helpers
+
+    /// Creates a test image of specified size
+    private func createTestImage(width: CGFloat, height: CGFloat, color: NSColor = .red) -> NSImage {
+        let image = NSImage(size: NSSize(width: width, height: height))
+        image.lockFocus()
+        color.setFill()
+        NSRect(x: 0, y: 0, width: width, height: height).fill()
+        image.unlockFocus()
+        return image
+    }
+
+    // MARK: - Attachment Tests
+
+    func test_image_createsAttachment() {
+        let renderer = ImageRenderer()
+        let image = createTestImage(width: 100, height: 100)
+        let result = renderer.render(
+            ImageRenderer.Input(image: image, altText: "Test"),
+            theme: .default,
+            context: RenderContext()
+        )
+
+        let attachment = result.attribute(.attachment, at: 0, effectiveRange: nil)
+        XCTAssertNotNil(attachment)
+    }
+
+    func test_image_containsAttachmentCharacter() {
+        let renderer = ImageRenderer()
+        let image = createTestImage(width: 100, height: 100)
+        let result = renderer.render(
+            ImageRenderer.Input(image: image, altText: "Test"),
+            theme: .default,
+            context: RenderContext()
+        )
+
+        XCTAssertTrue(result.string.contains("\u{FFFC}"))
+    }
+
+    // MARK: - Accessibility Tests
+
+    func test_image_setsAccessibilityDescription() {
+        let renderer = ImageRenderer()
+        let image = createTestImage(width: 100, height: 100)
+        let result = renderer.render(
+            ImageRenderer.Input(image: image, altText: "A cute cat"),
+            theme: .default,
+            context: RenderContext()
+        )
+
+        guard let attachment = result.attribute(.attachment, at: 0, effectiveRange: nil) as? NSTextAttachment else {
+            XCTFail("Expected text attachment")
+            return
+        }
+        XCTAssertEqual(attachment.image?.accessibilityDescription, "A cute cat")
+    }
+
+    func test_image_emptyAltText_noAccessibilityDescription() {
+        let renderer = ImageRenderer()
+        let image = createTestImage(width: 100, height: 100)
+        let result = renderer.render(
+            ImageRenderer.Input(image: image, altText: ""),
+            theme: .default,
+            context: RenderContext()
+        )
+
+        guard let attachment = result.attribute(.attachment, at: 0, effectiveRange: nil) as? NSTextAttachment else {
+            XCTFail("Expected text attachment")
+            return
+        }
+        // Empty alt text should not set description (or set empty)
+        let description = attachment.image?.accessibilityDescription ?? ""
+        XCTAssertTrue(description.isEmpty)
+    }
+
+    // MARK: - Size Constraint Tests
+
+    func test_image_constrainsWidth() {
+        let renderer = ImageRenderer(maxWidth: 200)
+        let image = createTestImage(width: 500, height: 250)
+        let result = renderer.render(
+            ImageRenderer.Input(image: image, altText: "Wide"),
+            theme: .default,
+            context: RenderContext()
+        )
+
+        guard let attachment = result.attribute(.attachment, at: 0, effectiveRange: nil) as? NSTextAttachment else {
+            XCTFail("Expected text attachment")
+            return
+        }
+        XCTAssertLessThanOrEqual(attachment.bounds.width, 200)
+    }
+
+    func test_image_maintainsAspectRatio() {
+        let renderer = ImageRenderer(maxWidth: 100)
+        let image = createTestImage(width: 200, height: 100) // 2:1 aspect ratio
+        let result = renderer.render(
+            ImageRenderer.Input(image: image, altText: "Landscape"),
+            theme: .default,
+            context: RenderContext()
+        )
+
+        guard let attachment = result.attribute(.attachment, at: 0, effectiveRange: nil) as? NSTextAttachment else {
+            XCTFail("Expected text attachment")
+            return
+        }
+        let bounds = attachment.bounds
+        // Width should be constrained to 100, height should be 50 (maintaining 2:1)
+        XCTAssertEqual(bounds.width, 100, accuracy: 0.1)
+        XCTAssertEqual(bounds.height, 50, accuracy: 0.1)
+    }
+
+    func test_image_smallerThanMaxWidth_notScaled() {
+        let renderer = ImageRenderer(maxWidth: 500)
+        let image = createTestImage(width: 100, height: 100)
+        let result = renderer.render(
+            ImageRenderer.Input(image: image, altText: "Small"),
+            theme: .default,
+            context: RenderContext()
+        )
+
+        guard let attachment = result.attribute(.attachment, at: 0, effectiveRange: nil) as? NSTextAttachment else {
+            XCTFail("Expected text attachment")
+            return
+        }
+        // Image smaller than max width should keep original size
+        XCTAssertEqual(attachment.bounds.width, 100, accuracy: 0.1)
+        XCTAssertEqual(attachment.bounds.height, 100, accuracy: 0.1)
+    }
+
+    // MARK: - Spacing Tests
+
+    func test_image_addsTrailingNewline() {
+        let renderer = ImageRenderer()
+        let image = createTestImage(width: 100, height: 100)
+        let result = renderer.render(
+            ImageRenderer.Input(image: image, altText: "Test"),
+            theme: .default,
+            context: RenderContext()
+        )
+
+        XCTAssertTrue(result.string.hasSuffix("\n"))
+    }
+
+    // MARK: - Placeholder Tests
+
+    func test_image_nil_createsPlaceholder() {
+        let renderer = ImageRenderer()
+        let result = renderer.render(
+            ImageRenderer.Input(image: nil, altText: "Missing image"),
+            theme: .default,
+            context: RenderContext()
+        )
+
+        // Should still have content (placeholder text with alt)
+        XCTAssertTrue(result.string.contains("Missing image"))
+    }
+}


### PR DESCRIPTION
## Summary
- Uses `NSTextAttachment` for inline image display
- Constrains width to `maxWidth` while maintaining aspect ratio
- Sets accessibility description from alt text
- Creates placeholder text for missing images

## Test plan
- [x] 9 new tests pass covering:
  - Attachment creation
  - Accessibility descriptions
  - Width constraints and aspect ratio
  - Placeholder for nil images
- [x] SwiftLint passes
- [x] Build succeeds

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)