### PR TITLE
feat: add TableRenderer using NSTextTable

### DIFF
--- a/SwiftMarkdown.xcodeproj/project.pbxproj
+++ b/SwiftMarkdown.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		07F1D34279D9B638D91B0AA7 /* MarkdownThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83FBF53FC258DD5C224DC030 /* MarkdownThemeTests.swift */; };
 		0E5BC65A4C34D2C20A13C184 /* SyntaxTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D864EB38F9DA2270E06F31 /* SyntaxTheme.swift */; };
 		1046C44370268572EE44F2BA /* PreviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F1EBA2B5AC2DA7FBD61F12 /* PreviewViewController.swift */; };
+		11DB26C7DFC1EECE09BF3CBF /* TableRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6294250F45E0C54A4F91BF74 /* TableRenderer.swift */; };
 		1ADF709C413D3EF737BD00D6 /* SwiftMarkdownCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 327502C2C9568E4497D68E2D /* SwiftMarkdownCore.swift */; };
 		1D4D4F6C986946DEFDBEE790 /* GrammarManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B063556DF68B1428DE338C6 /* GrammarManagerTests.swift */; };
 		23C1B550A2B89FA6DE699D93 /* StrikethroughRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C24CF34A31CB46A0376CD64 /* StrikethroughRenderer.swift */; };
@@ -41,6 +42,7 @@
 		76D53BDF39461E0F4D4C0425 /* LinkRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71DB50CDF53477DC2D121D2 /* LinkRenderer.swift */; };
 		7BD7CFD302515677C6911CDF /* InlineCodeRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CC5212680E478B3FD2CFF8B /* InlineCodeRendererTests.swift */; };
 		7E4E0ADB9F632919888A92E7 /* SwiftMarkdownCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 95F447A42C55828BB50C30B5 /* SwiftMarkdownCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		836CFC0B9E575B1DDF95063A /* TableRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88A0ADE87146C0450F822618 /* TableRendererTests.swift */; };
 		8664876EDFD44FCB3F6F20AF /* SwiftMarkdownCoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D59B743B5EFB7435B9954AAA /* SwiftMarkdownCoreTests.swift */; };
 		89384A0DDFE6F3B93B6E8983 /* SwiftMarkdownQuickLook.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 6567C09B42A4181208919050 /* SwiftMarkdownQuickLook.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		89FEE35070D2A1C17AB6421A /* Markdown in Frameworks */ = {isa = PBXBuildFile; productRef = F10350C361C31733946A2AFA /* Markdown */; };
@@ -195,6 +197,7 @@
 		5CC9349E626F73A9860EEAF9 /* SettingsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsManager.swift; sourceTree = "<group>"; };
 		60DAB9333ACF98FC398657DF /* AsyncHTMLWalker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncHTMLWalker.swift; sourceTree = "<group>"; };
 		612239001FD5DED5060CBE48 /* CodeBlockRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeBlockRenderer.swift; sourceTree = "<group>"; };
+		6294250F45E0C54A4F91BF74 /* TableRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableRenderer.swift; sourceTree = "<group>"; };
 		6567C09B42A4181208919050 /* SwiftMarkdownQuickLook.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = SwiftMarkdownQuickLook.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		7130A40117A04774C2B20CA6 /* InlineCodeRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineCodeRenderer.swift; sourceTree = "<group>"; };
 		7849291C823F0BF4608BF436 /* SwiftMarkdown.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SwiftMarkdown.entitlements; sourceTree = "<group>"; };
@@ -207,6 +210,7 @@
 		83CD477C1EE8C81739449627 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		83FBF53FC258DD5C224DC030 /* MarkdownThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownThemeTests.swift; sourceTree = "<group>"; };
 		87150C18803EF1451036BBE8 /* String+HTML.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+HTML.swift"; sourceTree = "<group>"; };
+		88A0ADE87146C0450F822618 /* TableRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableRendererTests.swift; sourceTree = "<group>"; };
 		8CC5212680E478B3FD2CFF8B /* InlineCodeRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineCodeRendererTests.swift; sourceTree = "<group>"; };
 		95F447A42C55828BB50C30B5 /* SwiftMarkdownCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftMarkdownCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9B786F7F67635FFA4DB2D52B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -336,6 +340,7 @@
 				E1FA1DEF225F14B6475A9BD9 /* ParagraphRenderer.swift */,
 				DEAE279D0E3DDB19CE02E809 /* RenderContext.swift */,
 				3C24CF34A31CB46A0376CD64 /* StrikethroughRenderer.swift */,
+				6294250F45E0C54A4F91BF74 /* TableRenderer.swift */,
 			);
 			path = NativeRendering;
 			sourceTree = "<group>";
@@ -475,6 +480,7 @@
 				D59B743B5EFB7435B9954AAA /* SwiftMarkdownCoreTests.swift */,
 				C5D9247F726F851B63E511B7 /* SyntaxHighlighterTests.swift */,
 				5A5BCE3B3DF1F9E273618397 /* SyntaxThemeTests.swift */,
+				88A0ADE87146C0450F822618 /* TableRendererTests.swift */,
 			);
 			path = SwiftMarkdownTests;
 			sourceTree = "<group>";
@@ -675,6 +681,7 @@
 				8664876EDFD44FCB3F6F20AF /* SwiftMarkdownCoreTests.swift in Sources */,
 				9C2B9CA834D9FBFA2B467B8C /* SyntaxHighlighterTests.swift in Sources */,
 				B6BAEE9D266B0B4E25F36503 /* SyntaxThemeTests.swift in Sources */,
+				836CFC0B9E575B1DDF95063A /* TableRendererTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -718,6 +725,7 @@
 				1ADF709C413D3EF737BD00D6 /* SwiftMarkdownCore.swift in Sources */,
 				F3C0DBD72E43F100AE91CECE /* SyntaxHighlighter.swift in Sources */,
 				0E5BC65A4C34D2C20A13C184 /* SyntaxTheme.swift in Sources */,
+				11DB26C7DFC1EECE09BF3CBF /* TableRenderer.swift in Sources */,
 				5DEBE8F448112FD03EE248BD /* TreeSitterHighlighter.swift in Sources */,
 				E7D3884E4639CDCC92F60336 /* TreeSitterTokenProcessor.swift in Sources */,
 			);

--- a/SwiftMarkdownCore/NativeRendering/TableRenderer.swift
+++ b/SwiftMarkdownCore/NativeRendering/TableRenderer.swift
@@ -1,0 +1,160 @@
+import AppKit
+
+/// Renders markdown tables to NSAttributedString using NSTextTable.
+///
+/// Tables are rendered using AppKit's `NSTextTable` and `NSTextTableBlock` APIs,
+/// which keep everything within the attributed string and preserve text selection.
+///
+/// ## Example
+/// ```swift
+/// let renderer = TableRenderer()
+/// let headers = [NSAttributedString(string: "Name"), NSAttributedString(string: "Value")]
+/// let rows = [[NSAttributedString(string: "foo"), NSAttributedString(string: "42")]]
+/// let result = renderer.render(
+///     TableRenderer.Input(headers: headers, rows: rows),
+///     theme: .default,
+///     context: RenderContext()
+/// )
+/// ```
+public struct TableRenderer: MarkdownElementRenderer {
+    /// Column alignment options.
+    public enum Alignment {
+        case left
+        case center
+        case right
+
+        fileprivate var textAlignment: NSTextAlignment {
+            switch self {
+            case .left: return .left
+            case .center: return .center
+            case .right: return .right
+            }
+        }
+    }
+
+    /// Input for table rendering.
+    public struct Input {
+        /// Header cells.
+        public let headers: [NSAttributedString]
+        /// Data rows, each containing cells.
+        public let rows: [[NSAttributedString]]
+        /// Column alignments (defaults to left for all).
+        public let alignments: [Alignment]
+
+        public init(
+            headers: [NSAttributedString],
+            rows: [[NSAttributedString]],
+            alignments: [Alignment]? = nil
+        ) {
+            self.headers = headers
+            self.rows = rows
+            self.alignments = alignments ?? Array(repeating: .left, count: headers.count)
+        }
+    }
+
+    /// Internal struct to group cell rendering parameters.
+    private struct CellConfig {
+        let content: NSAttributedString
+        let table: NSTextTable
+        let row: Int
+        let column: Int
+        let isHeader: Bool
+        let alignment: Alignment
+    }
+
+    public init() {}
+
+    public func render(_ input: Input, theme: MarkdownTheme, context: RenderContext) -> NSAttributedString {
+        let columnCount = input.headers.count
+
+        // Handle empty table
+        guard columnCount > 0 else {
+            return NSAttributedString(string: "\n")
+        }
+
+        let result = NSMutableAttributedString()
+
+        // Create the table
+        let table = NSTextTable()
+        table.numberOfColumns = columnCount
+        table.collapsesBorders = true
+
+        // Render header row
+        for (colIndex, header) in input.headers.enumerated() {
+            let config = CellConfig(
+                content: header,
+                table: table,
+                row: 0,
+                column: colIndex,
+                isHeader: true,
+                alignment: alignment(for: colIndex, in: input)
+            )
+            result.append(renderCell(config, theme: theme))
+        }
+
+        // Render data rows
+        for (rowIndex, row) in input.rows.enumerated() {
+            for (colIndex, cell) in row.enumerated() {
+                let config = CellConfig(
+                    content: cell,
+                    table: table,
+                    row: rowIndex + 1, // +1 for header row
+                    column: colIndex,
+                    isHeader: false,
+                    alignment: alignment(for: colIndex, in: input)
+                )
+                result.append(renderCell(config, theme: theme))
+            }
+        }
+
+        return result
+    }
+
+    private func renderCell(_ config: CellConfig, theme: MarkdownTheme) -> NSAttributedString {
+        // Create the table block for this cell
+        let block = NSTextTableBlock(
+            table: config.table,
+            startingRow: config.row,
+            rowSpan: 1,
+            startingColumn: config.column,
+            columnSpan: 1
+        )
+
+        // Style the block
+        block.setWidth(0.5, type: .absoluteValueType, for: .border)
+        block.setBorderColor(.separatorColor)
+        block.setContentWidth(100, type: .percentageValueType)
+
+        if config.isHeader {
+            block.backgroundColor = NSColor.windowBackgroundColor
+        }
+
+        // Set padding
+        block.setWidth(4, type: .absoluteValueType, for: .padding)
+
+        // Create paragraph style with the table block
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.textBlocks = [block]
+        paragraphStyle.alignment = config.alignment.textAlignment
+
+        // Build the cell string (must end with newline for NSTextTable)
+        let cellString = NSMutableAttributedString(attributedString: config.content)
+        cellString.append(NSAttributedString(string: "\n"))
+
+        // Apply attributes
+        let fullRange = NSRange(location: 0, length: cellString.length)
+        cellString.addAttribute(.paragraphStyle, value: paragraphStyle, range: fullRange)
+        let font = config.isHeader ? theme.headingFont(level: 6) : theme.bodyFont
+        cellString.addAttribute(.font, value: font, range: fullRange)
+        cellString.addAttribute(.foregroundColor, value: theme.textColor, range: fullRange)
+
+        return cellString
+    }
+
+    private func alignment(for column: Int, in input: Input) -> Alignment {
+        guard column < input.alignments.count else {
+            return .left
+        }
+        return input.alignments[column]
+    }
+}

--- a/SwiftMarkdownTests/TableRendererTests.swift
+++ b/SwiftMarkdownTests/TableRendererTests.swift
@@ -1,0 +1,255 @@
+import XCTest
+@testable import SwiftMarkdownCore
+
+final class TableRendererTests: XCTestCase {
+    // MARK: - Content Tests
+
+    func test_table_rendersAllCells() {
+        let renderer = TableRenderer()
+        let headers = [NSAttributedString(string: "A"), NSAttributedString(string: "B")]
+        let rows = [
+            [NSAttributedString(string: "1"), NSAttributedString(string: "2")],
+            [NSAttributedString(string: "3"), NSAttributedString(string: "4")]
+        ]
+        let result = renderer.render(
+            TableRenderer.Input(headers: headers, rows: rows),
+            theme: .default,
+            context: RenderContext()
+        )
+
+        XCTAssertTrue(result.string.contains("A"))
+        XCTAssertTrue(result.string.contains("B"))
+        XCTAssertTrue(result.string.contains("1"))
+        XCTAssertTrue(result.string.contains("4"))
+    }
+
+    func test_table_singleColumn() {
+        let renderer = TableRenderer()
+        let headers = [NSAttributedString(string: "Header")]
+        let rows = [[NSAttributedString(string: "Cell")]]
+        let result = renderer.render(
+            TableRenderer.Input(headers: headers, rows: rows),
+            theme: .default,
+            context: RenderContext()
+        )
+
+        XCTAssertTrue(result.string.contains("Header"))
+        XCTAssertTrue(result.string.contains("Cell"))
+    }
+
+    func test_table_multipleRows() {
+        let renderer = TableRenderer()
+        let headers = [NSAttributedString(string: "Col")]
+        let rows = [
+            [NSAttributedString(string: "Row1")],
+            [NSAttributedString(string: "Row2")],
+            [NSAttributedString(string: "Row3")]
+        ]
+        let result = renderer.render(
+            TableRenderer.Input(headers: headers, rows: rows),
+            theme: .default,
+            context: RenderContext()
+        )
+
+        XCTAssertTrue(result.string.contains("Row1"))
+        XCTAssertTrue(result.string.contains("Row2"))
+        XCTAssertTrue(result.string.contains("Row3"))
+    }
+
+    // MARK: - Structure Tests
+
+    func test_table_hasTextTableBlocks() {
+        let renderer = TableRenderer()
+        let headers = [NSAttributedString(string: "A")]
+        let rows = [[NSAttributedString(string: "1")]]
+        let result = renderer.render(
+            TableRenderer.Input(headers: headers, rows: rows),
+            theme: .default,
+            context: RenderContext()
+        )
+
+        var foundTableBlock = false
+        result.enumerateAttribute(
+            .paragraphStyle,
+            in: NSRange(location: 0, length: result.length)
+        ) { value, _, _ in
+            if let style = value as? NSParagraphStyle,
+               let block = style.textBlocks.first as? NSTextTableBlock {
+                foundTableBlock = true
+                _ = block // Silence warning
+            }
+        }
+        XCTAssertTrue(foundTableBlock)
+    }
+
+    func test_table_correctColumnCount() {
+        let renderer = TableRenderer()
+        let headers = [
+            NSAttributedString(string: "A"),
+            NSAttributedString(string: "B"),
+            NSAttributedString(string: "C")
+        ]
+        let rows = [[
+            NSAttributedString(string: "1"),
+            NSAttributedString(string: "2"),
+            NSAttributedString(string: "3")
+        ]]
+        let result = renderer.render(
+            TableRenderer.Input(headers: headers, rows: rows),
+            theme: .default,
+            context: RenderContext()
+        )
+
+        var maxColumn = -1
+        result.enumerateAttribute(
+            .paragraphStyle,
+            in: NSRange(location: 0, length: result.length)
+        ) { value, _, _ in
+            if let style = value as? NSParagraphStyle,
+               let block = style.textBlocks.first as? NSTextTableBlock {
+                maxColumn = max(maxColumn, block.startingColumn)
+            }
+        }
+        XCTAssertEqual(maxColumn, 2) // 0-indexed, 3 columns = max index 2
+    }
+
+    // MARK: - Header Tests
+
+    func test_table_headerRowHasBackground() {
+        let renderer = TableRenderer()
+        let headers = [NSAttributedString(string: "Header")]
+        let rows = [[NSAttributedString(string: "Cell")]]
+        let result = renderer.render(
+            TableRenderer.Input(headers: headers, rows: rows),
+            theme: .default,
+            context: RenderContext()
+        )
+
+        let headerRange = (result.string as NSString).range(of: "Header")
+        guard headerRange.location != NSNotFound else {
+            XCTFail("Header not found")
+            return
+        }
+
+        guard let style = result.attribute(.paragraphStyle, at: headerRange.location, effectiveRange: nil) as? NSParagraphStyle,
+              let block = style.textBlocks.first as? NSTextTableBlock else {
+            XCTFail("Expected table block")
+            return
+        }
+
+        XCTAssertNotNil(block.backgroundColor)
+    }
+
+    // MARK: - Alignment Tests
+
+    func test_table_leftAlignment() {
+        let renderer = TableRenderer()
+        let headers = [NSAttributedString(string: "Left")]
+        let rows = [[NSAttributedString(string: "text")]]
+        let result = renderer.render(
+            TableRenderer.Input(headers: headers, rows: rows, alignments: [.left]),
+            theme: .default,
+            context: RenderContext()
+        )
+
+        let textRange = (result.string as NSString).range(of: "text")
+        guard textRange.location != NSNotFound else {
+            XCTFail("Text not found")
+            return
+        }
+
+        guard let style = result.attribute(.paragraphStyle, at: textRange.location, effectiveRange: nil) as? NSParagraphStyle else {
+            XCTFail("Expected paragraph style")
+            return
+        }
+        XCTAssertEqual(style.alignment, .left)
+    }
+
+    func test_table_centerAlignment() {
+        let renderer = TableRenderer()
+        let headers = [NSAttributedString(string: "Center")]
+        let rows = [[NSAttributedString(string: "text")]]
+        let result = renderer.render(
+            TableRenderer.Input(headers: headers, rows: rows, alignments: [.center]),
+            theme: .default,
+            context: RenderContext()
+        )
+
+        let textRange = (result.string as NSString).range(of: "text")
+        guard textRange.location != NSNotFound else {
+            XCTFail("Text not found")
+            return
+        }
+
+        guard let style = result.attribute(.paragraphStyle, at: textRange.location, effectiveRange: nil) as? NSParagraphStyle else {
+            XCTFail("Expected paragraph style")
+            return
+        }
+        XCTAssertEqual(style.alignment, .center)
+    }
+
+    func test_table_rightAlignment() {
+        let renderer = TableRenderer()
+        let headers = [NSAttributedString(string: "Right")]
+        let rows = [[NSAttributedString(string: "text")]]
+        let result = renderer.render(
+            TableRenderer.Input(headers: headers, rows: rows, alignments: [.right]),
+            theme: .default,
+            context: RenderContext()
+        )
+
+        let textRange = (result.string as NSString).range(of: "text")
+        guard textRange.location != NSNotFound else {
+            XCTFail("Text not found")
+            return
+        }
+
+        guard let style = result.attribute(.paragraphStyle, at: textRange.location, effectiveRange: nil) as? NSParagraphStyle else {
+            XCTFail("Expected paragraph style")
+            return
+        }
+        XCTAssertEqual(style.alignment, .right)
+    }
+
+    // MARK: - Edge Cases
+
+    func test_table_emptyTable_returnsNewline() {
+        let renderer = TableRenderer()
+        let headers: [NSAttributedString] = []
+        let rows: [[NSAttributedString]] = []
+        let result = renderer.render(
+            TableRenderer.Input(headers: headers, rows: rows),
+            theme: .default,
+            context: RenderContext()
+        )
+
+        XCTAssertEqual(result.string, "\n")
+    }
+
+    func test_table_headersOnly_noRows() {
+        let renderer = TableRenderer()
+        let headers = [NSAttributedString(string: "A"), NSAttributedString(string: "B")]
+        let rows: [[NSAttributedString]] = []
+        let result = renderer.render(
+            TableRenderer.Input(headers: headers, rows: rows),
+            theme: .default,
+            context: RenderContext()
+        )
+
+        XCTAssertTrue(result.string.contains("A"))
+        XCTAssertTrue(result.string.contains("B"))
+    }
+
+    func test_table_addsTrailingNewline() {
+        let renderer = TableRenderer()
+        let headers = [NSAttributedString(string: "H")]
+        let rows = [[NSAttributedString(string: "C")]]
+        let result = renderer.render(
+            TableRenderer.Input(headers: headers, rows: rows),
+            theme: .default,
+            context: RenderContext()
+        )
+
+        XCTAssertTrue(result.string.hasSuffix("\n"))
+    }
+}


### PR DESCRIPTION
## Summary
- Uses `NSTextTable` and `NSTextTableBlock` for proper table layout
- Header row with distinct background color
- Column alignments (left, center, right)
- Borders and padding via NSTextTableBlock styling
- Preserves text selection across table cells

## Test plan
- [x] 12 new tests pass covering:
  - Cell content rendering
  - NSTextTableBlock structure
  - Column count verification
  - Header styling
  - All alignment types
  - Edge cases (empty, headers-only)
- [x] SwiftLint passes
- [x] Build succeeds

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)