### PR TITLE
feat: add DocumentRenderer and AttributedStringWalker (#91)

### DIFF
--- a/SwiftMarkdown.xcodeproj/project.pbxproj
+++ b/SwiftMarkdown.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		0E5BC65A4C34D2C20A13C184 /* SyntaxTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D864EB38F9DA2270E06F31 /* SyntaxTheme.swift */; };
 		1046C44370268572EE44F2BA /* PreviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F1EBA2B5AC2DA7FBD61F12 /* PreviewViewController.swift */; };
 		11DB26C7DFC1EECE09BF3CBF /* TableRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6294250F45E0C54A4F91BF74 /* TableRenderer.swift */; };
+		159AADCB16F842924F7A45E2 /* AttributedStringWalker.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF8B0D854612109E424AEE95 /* AttributedStringWalker.swift */; };
 		1ADF709C413D3EF737BD00D6 /* SwiftMarkdownCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 327502C2C9568E4497D68E2D /* SwiftMarkdownCore.swift */; };
 		1D4D4F6C986946DEFDBEE790 /* GrammarManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B063556DF68B1428DE338C6 /* GrammarManagerTests.swift */; };
 		23C1B550A2B89FA6DE699D93 /* StrikethroughRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C24CF34A31CB46A0376CD64 /* StrikethroughRenderer.swift */; };
@@ -42,6 +43,7 @@
 		76D53BDF39461E0F4D4C0425 /* LinkRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71DB50CDF53477DC2D121D2 /* LinkRenderer.swift */; };
 		7BD7CFD302515677C6911CDF /* InlineCodeRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CC5212680E478B3FD2CFF8B /* InlineCodeRendererTests.swift */; };
 		7E4E0ADB9F632919888A92E7 /* SwiftMarkdownCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 95F447A42C55828BB50C30B5 /* SwiftMarkdownCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		7EB5B41F0E18FBA0EF6D2C65 /* DocumentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E9E4A1F942AEC5816AB307 /* DocumentRenderer.swift */; };
 		836CFC0B9E575B1DDF95063A /* TableRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88A0ADE87146C0450F822618 /* TableRendererTests.swift */; };
 		8664876EDFD44FCB3F6F20AF /* SwiftMarkdownCoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D59B743B5EFB7435B9954AAA /* SwiftMarkdownCoreTests.swift */; };
 		89384A0DDFE6F3B93B6E8983 /* SwiftMarkdownQuickLook.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 6567C09B42A4181208919050 /* SwiftMarkdownQuickLook.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -73,6 +75,7 @@
 		C32DCDDECDFF9724F53C0D2C /* EmphasisRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7954C82A1FB5381C3ABE0707 /* EmphasisRenderer.swift */; };
 		C3B167FD38C733B112E277FF /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BB6B52D45ED0A11407D90A /* ContentView.swift */; };
 		C4F792554A8EB669109AD412 /* MarkdownParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89DC4E84AA6CB7A55815B7F /* MarkdownParserTests.swift */; };
+		C75752A82C10A92A43AB999F /* DocumentRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A933B3AAAA909685837D212 /* DocumentRendererTests.swift */; };
 		C8D6F02A3351E4E830D4FFD8 /* BlockquoteRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0920FB855ABA9CC68A905F87 /* BlockquoteRendererTests.swift */; };
 		CA4A0CBF37FF75E96508EAC4 /* ListRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FCA2AD44D0DD56826C82B4B /* ListRenderer.swift */; };
 		CBEBB2FA9092AD797D0FF830 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1D5E5838A8AEC4E0FDC523A2 /* Assets.xcassets */; };
@@ -213,6 +216,7 @@
 		88A0ADE87146C0450F822618 /* TableRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableRendererTests.swift; sourceTree = "<group>"; };
 		8CC5212680E478B3FD2CFF8B /* InlineCodeRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineCodeRendererTests.swift; sourceTree = "<group>"; };
 		95F447A42C55828BB50C30B5 /* SwiftMarkdownCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftMarkdownCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		9A933B3AAAA909685837D212 /* DocumentRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentRendererTests.swift; sourceTree = "<group>"; };
 		9B786F7F67635FFA4DB2D52B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		9F09FE7F417D7D382050EFEB /* HorizontalRuleRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HorizontalRuleRendererTests.swift; sourceTree = "<group>"; };
 		A1A8BA27FF96144B1141281F /* MarkdownTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownTheme.swift; sourceTree = "<group>"; };
@@ -222,6 +226,7 @@
 		AE6EA9AC7D0321DC237CAA56 /* PlainTextRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlainTextRendererTests.swift; sourceTree = "<group>"; };
 		B33EE552191E266ACEBB67F3 /* BlockquoteRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockquoteRenderer.swift; sourceTree = "<group>"; };
 		B5BB6B52D45ED0A11407D90A /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		B5E9E4A1F942AEC5816AB307 /* DocumentRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentRenderer.swift; sourceTree = "<group>"; };
 		BCAAFBA7E1B67A000AC2B618 /* GrammarManifest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrammarManifest.swift; sourceTree = "<group>"; };
 		BFAFFD7680E6AB06A9089D52 /* HorizontalRuleAttachmentCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HorizontalRuleAttachmentCell.swift; sourceTree = "<group>"; };
 		C34B61E7B48E091342EB990F /* ImageRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRendererTests.swift; sourceTree = "<group>"; };
@@ -240,6 +245,7 @@
 		DC245DFE823E1914F1368A1C /* SwiftMarkdownApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftMarkdownApp.swift; sourceTree = "<group>"; };
 		DE376EFAA7321A761C511B45 /* RenderContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenderContextTests.swift; sourceTree = "<group>"; };
 		DEAE279D0E3DDB19CE02E809 /* RenderContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenderContext.swift; sourceTree = "<group>"; };
+		DF8B0D854612109E424AEE95 /* AttributedStringWalker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributedStringWalker.swift; sourceTree = "<group>"; };
 		E0CDD889C6D996E0721E08B1 /* TreeSitterHighlighter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreeSitterHighlighter.swift; sourceTree = "<group>"; };
 		E1FA1DEF225F14B6475A9BD9 /* ParagraphRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParagraphRenderer.swift; sourceTree = "<group>"; };
 		E5F05025F27037503C6846C5 /* MarkdownFileValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownFileValidatorTests.swift; sourceTree = "<group>"; };
@@ -324,8 +330,10 @@
 		65FBBEE2C660B7670670C8FD /* NativeRendering */ = {
 			isa = PBXGroup;
 			children = (
+				DF8B0D854612109E424AEE95 /* AttributedStringWalker.swift */,
 				B33EE552191E266ACEBB67F3 /* BlockquoteRenderer.swift */,
 				612239001FD5DED5060CBE48 /* CodeBlockRenderer.swift */,
+				B5E9E4A1F942AEC5816AB307 /* DocumentRenderer.swift */,
 				7954C82A1FB5381C3ABE0707 /* EmphasisRenderer.swift */,
 				AAD5D435CF1AD986041106BF /* HeadingRenderer.swift */,
 				BFAFFD7680E6AB06A9089D52 /* HorizontalRuleAttachmentCell.swift */,
@@ -456,6 +464,7 @@
 			children = (
 				0920FB855ABA9CC68A905F87 /* BlockquoteRendererTests.swift */,
 				A622678EECA60D591402AC63 /* CodeBlockRendererTests.swift */,
+				9A933B3AAAA909685837D212 /* DocumentRendererTests.swift */,
 				F4D05EB02BCC6049F8103278 /* EmphasisRendererTests.swift */,
 				7B063556DF68B1428DE338C6 /* GrammarManagerTests.swift */,
 				8241641705639E7415FA4283 /* GrammarManifestTests.swift */,
@@ -658,6 +667,7 @@
 			files = (
 				C8D6F02A3351E4E830D4FFD8 /* BlockquoteRendererTests.swift in Sources */,
 				56D9CF15EB83D8C20BC0A36E /* CodeBlockRendererTests.swift in Sources */,
+				C75752A82C10A92A43AB999F /* DocumentRendererTests.swift in Sources */,
 				9CA4F91A86112062D1F0CE34 /* EmphasisRendererTests.swift in Sources */,
 				1D4D4F6C986946DEFDBEE790 /* GrammarManagerTests.swift in Sources */,
 				5A3162197FD39082852C1554 /* GrammarManifestTests.swift in Sources */,
@@ -690,8 +700,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				BFA78EFE0811FC9BB1CCA532 /* AsyncHTMLWalker.swift in Sources */,
+				159AADCB16F842924F7A45E2 /* AttributedStringWalker.swift in Sources */,
 				EC8570B8D884B57D91898634 /* BlockquoteRenderer.swift in Sources */,
 				0009EB03C15B74FED0F85D93 /* CodeBlockRenderer.swift in Sources */,
+				7EB5B41F0E18FBA0EF6D2C65 /* DocumentRenderer.swift in Sources */,
 				C32DCDDECDFF9724F53C0D2C /* EmphasisRenderer.swift in Sources */,
 				36BD2E50E187FB530399C70F /* FileSystemProtocol.swift in Sources */,
 				BD9282D7285DD285D40B7411 /* GrammarError.swift in Sources */,

--- a/SwiftMarkdownCore/NativeRendering/AttributedStringWalker.swift
+++ b/SwiftMarkdownCore/NativeRendering/AttributedStringWalker.swift
@@ -1,0 +1,404 @@
+import AppKit
+import Markdown
+
+/// Walks a swift-markdown AST and builds an NSAttributedString.
+///
+/// This struct traverses each node in the markdown document and dispatches
+/// to the appropriate element renderer based on node type.
+struct AttributedStringWalker {
+    /// The accumulated result.
+    private(set) var result = NSMutableAttributedString()
+
+    private let theme: MarkdownTheme
+    private var context: RenderContext
+
+    // Renderers
+    private let headingRenderer: HeadingRenderer
+    private let paragraphRenderer: ParagraphRenderer
+    private let codeBlockRenderer: CodeBlockRenderer
+    private let blockquoteRenderer: BlockquoteRenderer
+    private let listRenderer: ListRenderer
+    private let horizontalRuleRenderer: HorizontalRuleRenderer
+    private let tableRenderer: TableRenderer
+    private let imageRenderer: ImageRenderer
+    private let emphasisRenderer: EmphasisRenderer
+    private let inlineCodeRenderer: InlineCodeRenderer
+    private let linkRenderer: LinkRenderer
+    private let strikethroughRenderer: StrikethroughRenderer
+
+    init(
+        theme: MarkdownTheme,
+        context: RenderContext,
+        headingRenderer: HeadingRenderer,
+        paragraphRenderer: ParagraphRenderer,
+        codeBlockRenderer: CodeBlockRenderer,
+        blockquoteRenderer: BlockquoteRenderer,
+        listRenderer: ListRenderer,
+        horizontalRuleRenderer: HorizontalRuleRenderer,
+        tableRenderer: TableRenderer,
+        imageRenderer: ImageRenderer,
+        emphasisRenderer: EmphasisRenderer,
+        inlineCodeRenderer: InlineCodeRenderer,
+        linkRenderer: LinkRenderer,
+        strikethroughRenderer: StrikethroughRenderer
+    ) {
+        self.theme = theme
+        self.context = context
+        self.headingRenderer = headingRenderer
+        self.paragraphRenderer = paragraphRenderer
+        self.codeBlockRenderer = codeBlockRenderer
+        self.blockquoteRenderer = blockquoteRenderer
+        self.listRenderer = listRenderer
+        self.horizontalRuleRenderer = horizontalRuleRenderer
+        self.tableRenderer = tableRenderer
+        self.imageRenderer = imageRenderer
+        self.emphasisRenderer = emphasisRenderer
+        self.inlineCodeRenderer = inlineCodeRenderer
+        self.linkRenderer = linkRenderer
+        self.strikethroughRenderer = strikethroughRenderer
+    }
+
+    /// Visits a document and renders all its children.
+    mutating func visit(_ document: Document) {
+        for child in document.children {
+            visitBlock(child)
+        }
+    }
+
+    // MARK: - Block Visitors
+
+    private mutating func visitBlock(_ markup: Markup) {
+        switch markup {
+        case let heading as Heading:
+            visitHeading(heading)
+        case let paragraph as Paragraph:
+            visitParagraph(paragraph)
+        case let codeBlock as CodeBlock:
+            visitCodeBlock(codeBlock)
+        case let blockQuote as BlockQuote:
+            visitBlockQuote(blockQuote)
+        case let unorderedList as UnorderedList:
+            visitUnorderedList(unorderedList)
+        case let orderedList as OrderedList:
+            visitOrderedList(orderedList)
+        case let thematicBreak as ThematicBreak:
+            visitThematicBreak(thematicBreak)
+        case let table as Table:
+            visitTable(table)
+        case let htmlBlock as HTMLBlock:
+            visitHTMLBlock(htmlBlock)
+        default:
+            break
+        }
+    }
+
+    private mutating func visitHeading(_ heading: Heading) {
+        // Collect inline content as plain text for now
+        // TODO: Support rich inline content in headings
+        let text = collectInlineText(from: heading)
+        let input = HeadingRenderer.Input(text: text, level: heading.level)
+        result.append(headingRenderer.render(input, theme: theme, context: context))
+    }
+
+    private mutating func visitParagraph(_ paragraph: Paragraph) {
+        // Render inline content with formatting
+        let inlineContent = renderInlineChildren(of: paragraph)
+        result.append(inlineContent)
+
+        // Add paragraph newline
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.paragraphSpacing = theme.paragraphSpacing
+        result.append(NSAttributedString(string: "\n", attributes: [.paragraphStyle: paragraphStyle]))
+    }
+
+    private mutating func visitCodeBlock(_ codeBlock: CodeBlock) {
+        let input = CodeBlockRenderer.Input(code: codeBlock.code, language: codeBlock.language)
+        result.append(codeBlockRenderer.render(input, theme: theme, context: context))
+    }
+
+    private mutating func visitBlockQuote(_ blockQuote: BlockQuote) {
+        // Collect the block quote content
+        let content = NSMutableAttributedString()
+        for child in blockQuote.children {
+            if let paragraph = child as? Paragraph {
+                let inlineContent = renderInlineChildren(of: paragraph)
+                content.append(inlineContent)
+            }
+        }
+
+        let nestedContext = context.nested()
+        result.append(blockquoteRenderer.render(content, theme: theme, context: nestedContext))
+    }
+
+    private mutating func visitUnorderedList(_ list: UnorderedList) {
+        var items: [MarkdownListItem] = []
+        for listItem in list.listItems {
+            items.append(buildListItem(listItem, isOrdered: false))
+        }
+        let input = ListRenderer.Input(items: items, isOrdered: false)
+        result.append(listRenderer.render(input, theme: theme, context: context))
+    }
+
+    private mutating func visitOrderedList(_ list: OrderedList) {
+        var items: [MarkdownListItem] = []
+        for listItem in list.listItems {
+            items.append(buildListItem(listItem, isOrdered: true))
+        }
+        let input = ListRenderer.Input(items: items, isOrdered: true)
+        result.append(listRenderer.render(input, theme: theme, context: context))
+    }
+
+    private func buildListItem(_ listItem: ListItem, isOrdered: Bool) -> MarkdownListItem {
+        // Get the content (usually a paragraph)
+        let content = NSMutableAttributedString()
+        var nestedItems: [MarkdownListItem]?
+        var nestedOrdered = false
+
+        for child in listItem.children {
+            if let paragraph = child as? Paragraph {
+                var tempWalker = self
+                let inlineContent = tempWalker.renderInlineChildren(of: paragraph)
+                content.append(inlineContent)
+            } else if let nestedUnordered = child as? UnorderedList {
+                var nested: [MarkdownListItem] = []
+                for item in nestedUnordered.listItems {
+                    nested.append(buildListItem(item, isOrdered: false))
+                }
+                nestedItems = nested
+                nestedOrdered = false
+            } else if let nestedOrderedList = child as? OrderedList {
+                var nested: [MarkdownListItem] = []
+                for item in nestedOrderedList.listItems {
+                    nested.append(buildListItem(item, isOrdered: true))
+                }
+                nestedItems = nested
+                nestedOrdered = true
+            }
+        }
+
+        return MarkdownListItem(
+            content: content,
+            children: nestedItems,
+            childrenOrdered: nestedOrdered
+        )
+    }
+
+    private mutating func visitThematicBreak(_: ThematicBreak) {
+        result.append(horizontalRuleRenderer.render((), theme: theme, context: context))
+    }
+
+    private mutating func visitTable(_ table: Table) {
+        // Render headers
+        let headers: [NSAttributedString] = table.head.cells.map { cell in
+            let content = NSMutableAttributedString()
+            var tempWalker = self
+            for child in cell.children {
+                content.append(tempWalker.renderInlineMarkup(child))
+            }
+            return content
+        }
+
+        // Render rows
+        let rows: [[NSAttributedString]] = table.body.rows.map { row in
+            row.cells.map { cell in
+                let content = NSMutableAttributedString()
+                var tempWalker = self
+                for child in cell.children {
+                    content.append(tempWalker.renderInlineMarkup(child))
+                }
+                return content
+            }
+        }
+
+        // Get alignments
+        let alignments: [TableRenderer.Alignment] = table.columnAlignments.map { alignment in
+            switch alignment {
+            case .center:
+                return .center
+            case .right:
+                return .right
+            case .left, nil:
+                return .left
+            }
+        }
+
+        let input = TableRenderer.Input(headers: headers, rows: rows, alignments: alignments)
+        result.append(tableRenderer.render(input, theme: theme, context: context))
+    }
+
+    private mutating func visitHTMLBlock(_ htmlBlock: HTMLBlock) {
+        // Render HTML blocks as plain text
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: theme.bodyFont,
+            .foregroundColor: theme.textColor
+        ]
+        result.append(NSAttributedString(string: htmlBlock.rawHTML + "\n", attributes: attributes))
+    }
+
+    // MARK: - Inline Rendering
+
+    private mutating func renderInlineChildren(of container: some Markup) -> NSAttributedString {
+        let content = NSMutableAttributedString()
+        for child in container.children {
+            content.append(renderInlineMarkup(child))
+        }
+        return content
+    }
+
+    private mutating func renderInlineMarkup(_ markup: Markup) -> NSAttributedString {
+        // Try text formatting elements first
+        if let result = renderTextFormatting(markup) {
+            return result
+        }
+        // Try other inline elements
+        return renderOtherInline(markup)
+    }
+
+    private mutating func renderTextFormatting(_ markup: Markup) -> NSAttributedString? {
+        switch markup {
+        case let text as Text:
+            return renderText(text)
+        case let emphasis as Emphasis:
+            return renderEmphasis(emphasis)
+        case let strong as Strong:
+            return renderStrong(strong)
+        case let strikethrough as Strikethrough:
+            return renderStrikethrough(strikethrough)
+        case let inlineCode as InlineCode:
+            return renderInlineCode(inlineCode)
+        default:
+            return nil
+        }
+    }
+
+    private mutating func renderOtherInline(_ markup: Markup) -> NSAttributedString {
+        switch markup {
+        case let link as Link:
+            return renderLink(link)
+        case let image as Image:
+            return renderImage(image)
+        case let softBreak as SoftBreak:
+            return renderSoftBreak(softBreak)
+        case let lineBreak as LineBreak:
+            return renderLineBreak(lineBreak)
+        case let inlineHTML as InlineHTML:
+            return renderInlineHTML(inlineHTML)
+        default:
+            return NSAttributedString()
+        }
+    }
+
+    private func renderText(_ text: Text) -> NSAttributedString {
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: theme.bodyFont,
+            .foregroundColor: theme.textColor
+        ]
+        return NSAttributedString(string: text.string, attributes: attributes)
+    }
+
+    private mutating func renderEmphasis(_ emphasis: Emphasis) -> NSAttributedString {
+        // Check if children contain Strong for bold+italic
+        var hasBoldItalic = false
+        var innerContent = ""
+
+        for child in emphasis.children {
+            if let strong = child as? Strong {
+                hasBoldItalic = true
+                innerContent += collectInlineText(from: strong)
+            } else if let text = child as? Text {
+                innerContent += text.string
+            } else {
+                innerContent += collectInlineText(from: child)
+            }
+        }
+
+        let style: EmphasisRenderer.Style = hasBoldItalic ? .boldItalic : .italic
+        let input = EmphasisRenderer.Input(text: innerContent, style: style)
+        return emphasisRenderer.render(input, theme: theme, context: context)
+    }
+
+    private mutating func renderStrong(_ strong: Strong) -> NSAttributedString {
+        // Check if children contain emphasis for bold+italic
+        var hasBoldItalic = false
+        var innerContent = ""
+
+        for child in strong.children {
+            if let emphasis = child as? Emphasis {
+                hasBoldItalic = true
+                innerContent += collectInlineText(from: emphasis)
+            } else if let text = child as? Text {
+                innerContent += text.string
+            }
+        }
+
+        let style: EmphasisRenderer.Style = hasBoldItalic ? .boldItalic : .bold
+        let input = EmphasisRenderer.Input(text: innerContent, style: style)
+        return emphasisRenderer.render(input, theme: theme, context: context)
+    }
+
+    private func renderStrikethrough(_ strikethrough: Strikethrough) -> NSAttributedString {
+        let content = collectInlineText(from: strikethrough)
+        return strikethroughRenderer.render(content, theme: theme, context: context)
+    }
+
+    private func renderInlineCode(_ inlineCode: InlineCode) -> NSAttributedString {
+        return inlineCodeRenderer.render(inlineCode.code, theme: theme, context: context)
+    }
+
+    private mutating func renderLink(_ link: Link) -> NSAttributedString {
+        let text = collectInlineText(from: link)
+        guard let url = link.destination.flatMap({ URL(string: $0) }) else {
+            // Fallback to plain text if URL is invalid
+            return renderText(Text(text))
+        }
+        let input = LinkRenderer.Input(text: text, url: url)
+        return linkRenderer.render(input, theme: theme, context: context)
+    }
+
+    private func renderImage(_ image: Image) -> NSAttributedString {
+        // For now, we don't load images from URLs during rendering
+        // The image source would need to be resolved externally
+        let input = ImageRenderer.Input(image: nil, altText: image.plainText)
+        return imageRenderer.render(input, theme: theme, context: context)
+    }
+
+    private func renderSoftBreak(_: SoftBreak) -> NSAttributedString {
+        // Soft break = single newline in source = space in output
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: theme.bodyFont,
+            .foregroundColor: theme.textColor
+        ]
+        return NSAttributedString(string: " ", attributes: attributes)
+    }
+
+    private func renderLineBreak(_: LineBreak) -> NSAttributedString {
+        // Hard break (two spaces + newline) = actual line break
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: theme.bodyFont,
+            .foregroundColor: theme.textColor
+        ]
+        return NSAttributedString(string: "\n", attributes: attributes)
+    }
+
+    private func renderInlineHTML(_ inlineHTML: InlineHTML) -> NSAttributedString {
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: theme.bodyFont,
+            .foregroundColor: theme.textColor
+        ]
+        return NSAttributedString(string: inlineHTML.rawHTML, attributes: attributes)
+    }
+
+    // MARK: - Helpers
+
+    private func collectInlineText(from markup: some Markup) -> String {
+        var text = ""
+        for child in markup.children {
+            if let textNode = child as? Text {
+                text += textNode.string
+            } else {
+                text += collectInlineText(from: child)
+            }
+        }
+        return text
+    }
+}

--- a/SwiftMarkdownCore/NativeRendering/DocumentRenderer.swift
+++ b/SwiftMarkdownCore/NativeRendering/DocumentRenderer.swift
@@ -1,0 +1,74 @@
+import AppKit
+import Markdown
+
+/// Renders a complete markdown document to NSAttributedString.
+///
+/// This is the main entry point for native rendering. It traverses the swift-markdown
+/// AST and dispatches to specialized element renderers for each node type.
+///
+/// ## Example
+/// ```swift
+/// let renderer = DocumentRenderer()
+/// let document = Document(parsing: "# Hello\n\nWorld")
+/// let result = renderer.render(document, theme: .default, context: RenderContext())
+/// ```
+public struct DocumentRenderer {
+    private let headingRenderer: HeadingRenderer
+    private let paragraphRenderer: ParagraphRenderer
+    private let codeBlockRenderer: CodeBlockRenderer
+    private let blockquoteRenderer: BlockquoteRenderer
+    private let listRenderer: ListRenderer
+    private let horizontalRuleRenderer: HorizontalRuleRenderer
+    private let tableRenderer: TableRenderer
+    private let imageRenderer: ImageRenderer
+    private let emphasisRenderer: EmphasisRenderer
+    private let inlineCodeRenderer: InlineCodeRenderer
+    private let linkRenderer: LinkRenderer
+    private let strikethroughRenderer: StrikethroughRenderer
+
+    /// Creates a document renderer with default element renderers.
+    public init() {
+        self.headingRenderer = HeadingRenderer()
+        self.paragraphRenderer = ParagraphRenderer()
+        self.codeBlockRenderer = CodeBlockRenderer()
+        self.blockquoteRenderer = BlockquoteRenderer()
+        self.listRenderer = ListRenderer()
+        self.horizontalRuleRenderer = HorizontalRuleRenderer()
+        self.tableRenderer = TableRenderer()
+        self.imageRenderer = ImageRenderer()
+        self.emphasisRenderer = EmphasisRenderer()
+        self.inlineCodeRenderer = InlineCodeRenderer()
+        self.linkRenderer = LinkRenderer()
+        self.strikethroughRenderer = StrikethroughRenderer()
+    }
+
+    /// Renders a markdown document to an attributed string.
+    ///
+    /// - Parameters:
+    ///   - document: The parsed markdown document.
+    ///   - theme: The theme for styling.
+    ///   - context: The rendering context.
+    /// - Returns: The rendered attributed string.
+    public func render(_ document: Document, theme: MarkdownTheme, context: RenderContext) -> NSAttributedString {
+        var walker = AttributedStringWalker(
+            theme: theme,
+            context: context,
+            headingRenderer: headingRenderer,
+            paragraphRenderer: paragraphRenderer,
+            codeBlockRenderer: codeBlockRenderer,
+            blockquoteRenderer: blockquoteRenderer,
+            listRenderer: listRenderer,
+            horizontalRuleRenderer: horizontalRuleRenderer,
+            tableRenderer: tableRenderer,
+            imageRenderer: imageRenderer,
+            emphasisRenderer: emphasisRenderer,
+            inlineCodeRenderer: inlineCodeRenderer,
+            linkRenderer: linkRenderer,
+            strikethroughRenderer: strikethroughRenderer
+        )
+
+        walker.visit(document)
+
+        return walker.result
+    }
+}

--- a/SwiftMarkdownTests/DocumentRendererTests.swift
+++ b/SwiftMarkdownTests/DocumentRendererTests.swift
@@ -1,0 +1,350 @@
+import XCTest
+import Markdown
+@testable import SwiftMarkdownCore
+
+final class DocumentRendererTests: XCTestCase {
+    // MARK: - Empty Document Tests
+
+    func test_emptyDocument_returnsEmptyString() {
+        let renderer = DocumentRenderer()
+        let document = Document(parsing: "")
+        let result = renderer.render(document, theme: .default, context: RenderContext())
+
+        XCTAssertEqual(result.string, "")
+    }
+
+    // MARK: - Single Element Tests
+
+    func test_singleParagraph_rendersParagraph() {
+        let renderer = DocumentRenderer()
+        let document = Document(parsing: "Hello world")
+        let result = renderer.render(document, theme: .default, context: RenderContext())
+
+        XCTAssertTrue(result.string.contains("Hello world"))
+    }
+
+    func test_singleHeading_rendersHeading() {
+        let renderer = DocumentRenderer()
+        let document = Document(parsing: "# Title")
+        let result = renderer.render(document, theme: .default, context: RenderContext())
+
+        XCTAssertTrue(result.string.contains("Title"))
+        guard let font = result.attribute(.font, at: 0, effectiveRange: nil) as? NSFont else {
+            XCTFail("Expected font attribute")
+            return
+        }
+        XCTAssertTrue(font.fontDescriptor.symbolicTraits.contains(.bold))
+    }
+
+    // MARK: - Multiple Element Tests
+
+    func test_headingAndParagraph_rendersInOrder() {
+        let renderer = DocumentRenderer()
+        let markdown = """
+        # Title
+
+        Some paragraph text
+        """
+        let document = Document(parsing: markdown)
+        let result = renderer.render(document, theme: .default, context: RenderContext())
+
+        let titleRange = (result.string as NSString).range(of: "Title")
+        let paragraphRange = (result.string as NSString).range(of: "Some paragraph text")
+
+        XCTAssertNotEqual(titleRange.location, NSNotFound)
+        XCTAssertNotEqual(paragraphRange.location, NSNotFound)
+        XCTAssertLessThan(titleRange.location, paragraphRange.location)
+    }
+
+    func test_multipleParagraphs_rendersSeparated() {
+        let renderer = DocumentRenderer()
+        let markdown = """
+        First paragraph.
+
+        Second paragraph.
+        """
+        let document = Document(parsing: markdown)
+        let result = renderer.render(document, theme: .default, context: RenderContext())
+
+        XCTAssertTrue(result.string.contains("First paragraph"))
+        XCTAssertTrue(result.string.contains("Second paragraph"))
+    }
+
+    // MARK: - Inline Element Tests
+
+    func test_paragraphWithBold_rendersWithBoldAttribute() {
+        let renderer = DocumentRenderer()
+        let document = Document(parsing: "This is **bold** text")
+        let result = renderer.render(document, theme: .default, context: RenderContext())
+
+        let boldRange = (result.string as NSString).range(of: "bold")
+        guard boldRange.location != NSNotFound else {
+            XCTFail("Bold text not found")
+            return
+        }
+
+        guard let font = result.attribute(.font, at: boldRange.location, effectiveRange: nil) as? NSFont else {
+            XCTFail("Expected font attribute")
+            return
+        }
+        XCTAssertTrue(font.fontDescriptor.symbolicTraits.contains(.bold))
+    }
+
+    func test_paragraphWithItalic_rendersWithItalicAttribute() {
+        let renderer = DocumentRenderer()
+        let document = Document(parsing: "This is *italic* text")
+        let result = renderer.render(document, theme: .default, context: RenderContext())
+
+        let italicRange = (result.string as NSString).range(of: "italic")
+        guard italicRange.location != NSNotFound else {
+            XCTFail("Italic text not found")
+            return
+        }
+
+        guard let font = result.attribute(.font, at: italicRange.location, effectiveRange: nil) as? NSFont else {
+            XCTFail("Expected font attribute")
+            return
+        }
+        XCTAssertTrue(font.fontDescriptor.symbolicTraits.contains(.italic))
+    }
+
+    func test_paragraphWithInlineCode_rendersWithMonospaceFont() {
+        let renderer = DocumentRenderer()
+        let document = Document(parsing: "Use the `print()` function")
+        let result = renderer.render(document, theme: .default, context: RenderContext())
+
+        let codeRange = (result.string as NSString).range(of: "print()")
+        guard codeRange.location != NSNotFound else {
+            XCTFail("Inline code not found")
+            return
+        }
+
+        guard let font = result.attribute(.font, at: codeRange.location, effectiveRange: nil) as? NSFont else {
+            XCTFail("Expected font attribute")
+            return
+        }
+        XCTAssertTrue(font.fontName.lowercased().contains("mono") || font.isFixedPitch)
+    }
+
+    func test_paragraphWithLink_rendersWithLinkAttribute() {
+        let renderer = DocumentRenderer()
+        let document = Document(parsing: "Visit [Example](https://example.com)")
+        let result = renderer.render(document, theme: .default, context: RenderContext())
+
+        let linkRange = (result.string as NSString).range(of: "Example")
+        guard linkRange.location != NSNotFound else {
+            XCTFail("Link text not found")
+            return
+        }
+
+        let url = result.attribute(.link, at: linkRange.location, effectiveRange: nil) as? URL
+        XCTAssertEqual(url?.absoluteString, "https://example.com")
+    }
+
+    // MARK: - Block Element Tests
+
+    func test_codeBlock_rendersWithMonospaceFont() {
+        let renderer = DocumentRenderer()
+        let markdown = """
+        ```
+        let x = 1
+        ```
+        """
+        let document = Document(parsing: markdown)
+        let result = renderer.render(document, theme: .default, context: RenderContext())
+
+        let codeRange = (result.string as NSString).range(of: "let x = 1")
+        guard codeRange.location != NSNotFound else {
+            XCTFail("Code block content not found")
+            return
+        }
+
+        guard let font = result.attribute(.font, at: codeRange.location, effectiveRange: nil) as? NSFont else {
+            XCTFail("Expected font attribute")
+            return
+        }
+        XCTAssertTrue(font.fontName.lowercased().contains("mono") || font.isFixedPitch)
+    }
+
+    func test_blockquote_rendersWithIndent() {
+        let renderer = DocumentRenderer()
+        let document = Document(parsing: "> Quoted text")
+        let result = renderer.render(document, theme: .default, context: RenderContext())
+
+        XCTAssertTrue(result.string.contains("Quoted text"))
+    }
+
+    func test_unorderedList_rendersWithBullets() {
+        let renderer = DocumentRenderer()
+        let markdown = """
+        - Item 1
+        - Item 2
+        """
+        let document = Document(parsing: markdown)
+        let result = renderer.render(document, theme: .default, context: RenderContext())
+
+        XCTAssertTrue(result.string.contains("Item 1"))
+        XCTAssertTrue(result.string.contains("Item 2"))
+    }
+
+    func test_orderedList_rendersWithNumbers() {
+        let renderer = DocumentRenderer()
+        let markdown = """
+        1. First
+        2. Second
+        """
+        let document = Document(parsing: markdown)
+        let result = renderer.render(document, theme: .default, context: RenderContext())
+
+        XCTAssertTrue(result.string.contains("First"))
+        XCTAssertTrue(result.string.contains("Second"))
+        XCTAssertTrue(result.string.contains("1"))
+        XCTAssertTrue(result.string.contains("2"))
+    }
+
+    func test_horizontalRule_rendersAttachment() {
+        let renderer = DocumentRenderer()
+        let document = Document(parsing: "---")
+        let result = renderer.render(document, theme: .default, context: RenderContext())
+
+        var foundAttachment = false
+        result.enumerateAttribute(
+            .attachment,
+            in: NSRange(location: 0, length: result.length)
+        ) { value, _, _ in
+            if value != nil {
+                foundAttachment = true
+            }
+        }
+        XCTAssertTrue(foundAttachment)
+    }
+
+    func test_table_rendersAllCells() {
+        let renderer = DocumentRenderer()
+        let markdown = """
+        | A | B |
+        |---|---|
+        | 1 | 2 |
+        """
+        let document = Document(parsing: markdown)
+        let result = renderer.render(document, theme: .default, context: RenderContext())
+
+        XCTAssertTrue(result.string.contains("A"))
+        XCTAssertTrue(result.string.contains("B"))
+        XCTAssertTrue(result.string.contains("1"))
+        XCTAssertTrue(result.string.contains("2"))
+    }
+
+    // MARK: - Complex Document Tests
+
+    func test_complexDocument_rendersAllElements() {
+        let renderer = DocumentRenderer()
+        let markdown = """
+        # Main Title
+
+        This is a paragraph with **bold** and *italic* text.
+
+        ## Code Section
+
+        ```swift
+        func hello() {
+            print("Hello")
+        }
+        ```
+
+        - Item A
+        - Item B
+
+        > A quote
+        """
+        let document = Document(parsing: markdown)
+        let result = renderer.render(document, theme: .default, context: RenderContext())
+
+        XCTAssertTrue(result.string.contains("Main Title"))
+        XCTAssertTrue(result.string.contains("bold"))
+        XCTAssertTrue(result.string.contains("italic"))
+        XCTAssertTrue(result.string.contains("Code Section"))
+        XCTAssertTrue(result.string.contains("func hello()"))
+        XCTAssertTrue(result.string.contains("Item A"))
+        XCTAssertTrue(result.string.contains("Item B"))
+        XCTAssertTrue(result.string.contains("A quote"))
+    }
+
+    // MARK: - Theme Tests
+
+    func test_document_usesThemeColors() {
+        let renderer = DocumentRenderer()
+        let document = Document(parsing: "Hello")
+        let result = renderer.render(document, theme: .default, context: RenderContext())
+
+        let color = result.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor
+        XCTAssertNotNil(color)
+    }
+
+    // MARK: - Line Break Tests
+
+    func test_softBreak_rendersAsSpace() {
+        let renderer = DocumentRenderer()
+        // Soft break is a single newline within a paragraph
+        let markdown = "Line one\nLine two"
+        let document = Document(parsing: markdown)
+        let result = renderer.render(document, theme: .default, context: RenderContext())
+
+        XCTAssertTrue(result.string.contains("Line one"))
+        XCTAssertTrue(result.string.contains("Line two"))
+    }
+
+    func test_hardBreak_rendersAsNewline() {
+        let renderer = DocumentRenderer()
+        // Hard break is two spaces followed by newline
+        let markdown = "Line one  \nLine two"
+        let document = Document(parsing: markdown)
+        let result = renderer.render(document, theme: .default, context: RenderContext())
+
+        XCTAssertTrue(result.string.contains("Line one"))
+        XCTAssertTrue(result.string.contains("Line two"))
+    }
+
+    // MARK: - Strikethrough Tests
+
+    func test_strikethrough_rendersWithAttribute() {
+        let renderer = DocumentRenderer()
+        let document = Document(parsing: "This is ~~deleted~~ text")
+        let result = renderer.render(document, theme: .default, context: RenderContext())
+
+        let deletedRange = (result.string as NSString).range(of: "deleted")
+        guard deletedRange.location != NSNotFound else {
+            XCTFail("Strikethrough text not found")
+            return
+        }
+
+        let strikethrough = result.attribute(
+            .strikethroughStyle,
+            at: deletedRange.location,
+            effectiveRange: nil
+        ) as? Int
+        XCTAssertNotNil(strikethrough)
+        XCTAssertEqual(strikethrough, NSUnderlineStyle.single.rawValue)
+    }
+
+    // MARK: - Nested Inline Tests
+
+    func test_nestedInlineElements_composesCorrectly() {
+        let renderer = DocumentRenderer()
+        let document = Document(parsing: "This is ***bold italic*** text")
+        let result = renderer.render(document, theme: .default, context: RenderContext())
+
+        let boldItalicRange = (result.string as NSString).range(of: "bold italic")
+        guard boldItalicRange.location != NSNotFound else {
+            XCTFail("Bold italic text not found")
+            return
+        }
+
+        guard let font = result.attribute(.font, at: boldItalicRange.location, effectiveRange: nil) as? NSFont else {
+            XCTFail("Expected font attribute")
+            return
+        }
+        XCTAssertTrue(font.fontDescriptor.symbolicTraits.contains(.bold))
+        XCTAssertTrue(font.fontDescriptor.symbolicTraits.contains(.italic))
+    }
+}


### PR DESCRIPTION
## Summary
- Implements DocumentRenderer as the entry point for native markdown rendering
- Adds AttributedStringWalker to traverse swift-markdown AST and dispatch to element renderers
- Supports all block elements (headings, paragraphs, code blocks, lists, tables, blockquotes, horizontal rules)
- Supports all inline elements (emphasis, strong, strikethrough, links, inline code, images)
- Handles nested inline formatting (bold+italic)

## Test plan
- [x] 21 new unit tests covering document rendering
- [x] Tests for empty documents, single elements, multiple elements
- [x] Tests for all inline formatting (bold, italic, code, links, strikethrough)
- [x] Tests for all block elements (code blocks, lists, tables, blockquotes)
- [x] Tests for complex documents with mixed content
- [x] SwiftLint passes with strict mode

Closes #91