### PR TITLE
fix: use pre-built Query in LanguageConfiguration instead of bundle lookup

### DIFF
--- a/SwiftMarkdownCore/SyntaxHighlighting/LazyTreeSitterHighlighter.swift
+++ b/SwiftMarkdownCore/SyntaxHighlighting/LazyTreeSitterHighlighter.swift
@@ -159,8 +159,9 @@ public final class LazyTreeSitterHighlighter: HTMLSyntaxHighlighter, @unchecked 
             guard let queryData = querySource.data(using: .utf8) else {
                 return nil
             }
-            _ = try Query(language: grammar.language, data: queryData)
-            let config = try LanguageConfiguration(grammar.language, name: grammar.name)
+            let query = try Query(language: grammar.language, data: queryData)
+            let queries: [Query.Definition: Query] = [.highlights: query]
+            let config = LanguageConfiguration(grammar.language, name: grammar.name, queries: queries)
             languageConfigs[language] = config
             return config
         } catch {
@@ -187,8 +188,9 @@ public final class LazyTreeSitterHighlighter: HTMLSyntaxHighlighter, @unchecked 
                 guard let queryData = querySource.data(using: .utf8) else {
                     return []
                 }
-                _ = try Query(language: grammar.language, data: queryData)
-                config = try LanguageConfiguration(grammar.language, name: grammar.name)
+                let query = try Query(language: grammar.language, data: queryData)
+                let queries: [Query.Definition: Query] = [.highlights: query]
+                config = LanguageConfiguration(grammar.language, name: grammar.name, queries: queries)
                 languageConfigs[grammar.name] = config
             } catch {
                 return []

--- a/SwiftMarkdownCore/SyntaxHighlighting/TreeSitterHighlighter.swift
+++ b/SwiftMarkdownCore/SyntaxHighlighting/TreeSitterHighlighter.swift
@@ -104,8 +104,9 @@ public final class TreeSitterHighlighter: HTMLSyntaxHighlighter, @unchecked Send
             guard let queryData = querySource.data(using: .utf8) else {
                 return nil
             }
-            _ = try Query(language: grammar.language, data: queryData)
-            let config = try LanguageConfiguration(grammar.language, name: grammar.name)
+            let query = try Query(language: grammar.language, data: queryData)
+            let queries: [Query.Definition: Query] = [.highlights: query]
+            let config = LanguageConfiguration(grammar.language, name: grammar.name, queries: queries)
             languageConfigs[language] = config
             return config
         } catch {


### PR DESCRIPTION
## Summary
- Fixed bug where `TreeSitterHighlighter` and `LazyTreeSitterHighlighter` would silently fail to load grammars
- The issue was that after creating a `Query` from the highlights.scm file, the code discarded it and called `LanguageConfiguration(language, name:)` which expects an SPM bundle
- Changed to use `LanguageConfiguration(language, name:, queries:)` to pass the pre-built Query directly

## Test plan
- [x] All 19 SyntaxHighlighterTests now pass (previously 9 were failing)
- [x] Full test suite passes (416 tests)
- [x] SwiftLint passes

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)