### PR TITLE
perf: pre-load commonly used grammar dylibs at app startup

### DIFF
--- a/SwiftMarkdown/SwiftMarkdownApp.swift
+++ b/SwiftMarkdown/SwiftMarkdownApp.swift
@@ -5,6 +5,13 @@ import SwiftMarkdownCore
 struct SwiftMarkdownApp: App {
     @StateObject private var settingsManager = SettingsManager()
 
+    init() {
+        // Pre-load common grammars in background to reduce first-render latency
+        Task.detached(priority: .utility) {
+            await GrammarManager.shared.preloadCommonGrammars()
+        }
+    }
+
     var body: some Scene {
         WindowGroup {
             ContentView()


### PR DESCRIPTION
## Summary
- Add `preloadCommonGrammars()` method to `GrammarManager` that loads grammar dylibs in the background
- Call preload from `SwiftMarkdownApp.init()` using `Task.detached(priority: .utility)` - runs completely off UI thread
- Add `commonGrammars` constant with default languages: swift, python, javascript, typescript, json, yaml, bash, go, rust, java
- Only preloads grammars that are already installed (no downloads)

This eliminates the `dlopen()` latency (500KB-3MB per grammar) on first render for common languages.

## Test plan
- [x] All existing tests pass (416 tests)
- [x] SwiftLint passes
- [x] Verified preload runs on background thread (Task.detached with .utility priority)

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)