### PR TITLE
feat: Enable syntax highlighting in native rendering

### DIFF
--- a/SwiftMarkdown/DocumentViewModel.swift
+++ b/SwiftMarkdown/DocumentViewModel.swift
@@ -67,7 +67,7 @@ final class DocumentViewModel: ObservableObject {
     /// Render markdown content to an attributed string using native rendering.
     private func renderMarkdown(_ content: String) -> NSAttributedString {
         let document = MarkdownParser.parseDocument(content)
-        let renderer = DocumentRenderer()
+        let renderer = DocumentRenderer(syntaxHighlighter: LazyTreeSitterHighlighter.shared)
         let theme = MarkdownTheme.default
         let context = RenderContext()
         return renderer.render(document, theme: theme, context: context)

--- a/SwiftMarkdownCore/NativeRendering/DocumentRenderer.swift
+++ b/SwiftMarkdownCore/NativeRendering/DocumentRenderer.swift
@@ -27,10 +27,12 @@ public struct DocumentRenderer {
     private let strikethroughRenderer: StrikethroughRenderer
 
     /// Creates a document renderer with default element renderers.
-    public init() {
+    ///
+    /// - Parameter syntaxHighlighter: Optional syntax highlighter for code blocks.
+    public init(syntaxHighlighter: (any SyntaxHighlighter)? = nil) {
         self.headingRenderer = HeadingRenderer()
         self.paragraphRenderer = ParagraphRenderer()
-        self.codeBlockRenderer = CodeBlockRenderer()
+        self.codeBlockRenderer = CodeBlockRenderer(highlighter: syntaxHighlighter)
         self.blockquoteRenderer = BlockquoteRenderer()
         self.listRenderer = ListRenderer()
         self.horizontalRuleRenderer = HorizontalRuleRenderer()

--- a/SwiftMarkdownQuickLook/PreviewViewController.swift
+++ b/SwiftMarkdownQuickLook/PreviewViewController.swift
@@ -26,7 +26,7 @@ class PreviewViewController: NSViewController, QLPreviewingController {
             let content = try String(contentsOf: url, encoding: .utf8)
 
             let document = MarkdownParser.parseDocument(content)
-            let renderer = DocumentRenderer()
+            let renderer = DocumentRenderer(syntaxHighlighter: LazyTreeSitterHighlighter.shared)
             let theme = MarkdownTheme.default
             let context = RenderContext()
             let attributedString = renderer.render(document, theme: theme, context: context)


### PR DESCRIPTION
## Summary
- Wire up `LazyTreeSitterHighlighter` to `DocumentRenderer` for code block syntax highlighting
- Add `syntaxHighlighter` parameter to `DocumentRenderer` init
- Enable highlighting in both main app and Quick Look extension

## Changes
| File | Change |
|------|--------|
| `DocumentRenderer.swift` | Add optional `syntaxHighlighter` init param, pass to `CodeBlockRenderer` |
| `DocumentViewModel.swift` | Pass `LazyTreeSitterHighlighter.shared` to `DocumentRenderer` |
| `PreviewViewController.swift` | Same change for Quick Look extension |

## Performance
The architecture is already optimized:
- `LazyTreeSitterHighlighter.shared` singleton caches grammar configurations
- Common grammars pre-loaded at app startup (#76)
- Sync API gracefully falls back to plain text for non-installed grammars

## Test plan
- [x] Build succeeds
- [x] All tests pass
- [x] SwiftLint passes
- [ ] Manual verification with Swift, Python, JavaScript code blocks

Closes #108

🤖 Generated with Claude Code