### PR TITLE
Use NSTextBlock for code block backgrounds

### DIFF
--- a/SwiftMarkdownCore/NativeRendering/CodeBlockRenderer.swift
+++ b/SwiftMarkdownCore/NativeRendering/CodeBlockRenderer.swift
@@ -51,11 +51,18 @@ public struct CodeBlockRenderer: MarkdownElementRenderer {
     public func render(_ input: Input, theme: MarkdownTheme, context: RenderContext) -> NSAttributedString {
         let code = input.code.isEmpty ? "" : input.code
 
+        // Create text block for full-width background with padding
+        let codeBlock = NSTextBlock()
+        codeBlock.backgroundColor = theme.codeBlockBackground
+        codeBlock.setContentWidth(100, type: .percentageValueType)
+        codeBlock.setWidth(theme.codeBlockPadding, type: .absoluteValueType, for: .padding)
+        codeBlock.setWidth(theme.paragraphSpacing, type: .absoluteValueType, for: .margin, edge: .maxY)
+
         let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.textBlocks = [codeBlock]
         paragraphStyle.lineSpacing = 0
+        paragraphStyle.lineHeightMultiple = 0.9
         paragraphStyle.paragraphSpacingBefore = theme.paragraphSpacing
-        paragraphStyle.firstLineHeadIndent = theme.blockquoteIndent
-        paragraphStyle.headIndent = theme.blockquoteIndent
 
         let baseAttributes: [NSAttributedString.Key: Any] = [
             .font: theme.codeFont,

--- a/SwiftMarkdownCore/NativeRendering/MarkdownTheme.swift
+++ b/SwiftMarkdownCore/NativeRendering/MarkdownTheme.swift
@@ -57,6 +57,9 @@ public struct MarkdownTheme: Sendable {
     /// Line spacing multiplier.
     public let lineSpacing: CGFloat
 
+    /// Padding inside code blocks.
+    public let codeBlockPadding: CGFloat
+
     // MARK: - Initialization
 
     public init(
@@ -80,7 +83,8 @@ public struct MarkdownTheme: Sendable {
         paragraphSpacing: CGFloat = 12,
         listIndent: CGFloat = 24,
         blockquoteIndent: CGFloat = 16,
-        lineSpacing: CGFloat = 4
+        lineSpacing: CGFloat = 4,
+        codeBlockPadding: CGFloat = 8
     ) {
         self.headingFontSizes = headingFontSizes
         self.bodyFontSize = bodyFontSize
@@ -95,6 +99,7 @@ public struct MarkdownTheme: Sendable {
         self.listIndent = listIndent
         self.blockquoteIndent = blockquoteIndent
         self.lineSpacing = lineSpacing
+        self.codeBlockPadding = codeBlockPadding
     }
 
     // MARK: - Default Theme

--- a/SwiftMarkdownTests/CodeBlockRendererTests.swift
+++ b/SwiftMarkdownTests/CodeBlockRendererTests.swift
@@ -44,8 +44,13 @@ final class CodeBlockRendererTests: XCTestCase {
             context: RenderContext()
         )
 
-        let backgroundColor = result.attribute(.backgroundColor, at: 0, effectiveRange: nil) as? NSColor
-        XCTAssertNotNil(backgroundColor)
+        // Background is now on NSTextBlock, not as a text attribute
+        guard let style = result.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle,
+              let textBlock = style.textBlocks.first else {
+            XCTFail("Expected paragraph style with text block")
+            return
+        }
+        XCTAssertNotNil(textBlock.backgroundColor)
     }
 
     func test_codeBlock_backgroundSpansEntireCode() {
@@ -56,8 +61,9 @@ final class CodeBlockRendererTests: XCTestCase {
             context: RenderContext()
         )
 
+        // Background is now on NSTextBlock which spans the entire code block
         var range = NSRange(location: 0, length: 0)
-        _ = result.attribute(.backgroundColor, at: 0, effectiveRange: &range)
+        _ = result.attribute(.paragraphStyle, at: 0, effectiveRange: &range)
         XCTAssertEqual(range.length, result.length)
     }
 


### PR DESCRIPTION
## Summary

- Replace `.backgroundColor` text attribute with `NSTextBlock` for proper block-level styling
- Add `codeBlockPadding` theme property (8pt default)
- Use hybrid approach: NSTextBlock for container + `.backgroundColor` for filling gaps
- Set `lineHeightMultiple` to 0.9 for tighter code display
- Add bottom margin to code blocks for spacing from following content

## Test plan

- [x] Build succeeds
- [x] All 423 tests pass  
- [x] Visual testing shows solid background with padding (no stripe effect)

Closes #122